### PR TITLE
only use 0 as correlation id when explicitly configured (demo mode)

### DIFF
--- a/internal/api/connectors/cloudConnector.mock.go
+++ b/internal/api/connectors/cloudConnector.mock.go
@@ -20,6 +20,6 @@ func (this *cloudConnectorClientMock) SendCloudConnectorRequest(
 	correlationId uuid.UUID,
 	url string,
 ) (*string, error) {
-	id := uuid.UUID{}.String()
+	id := uuid.New().String()
 	return &id, nil
 }

--- a/internal/api/instrumentation/probes.go
+++ b/internal/api/instrumentation/probes.go
@@ -48,18 +48,13 @@ func InvalidRecipientId(ctx echo.Context, value string, err error) {
 	validationFailureTotal.WithLabelValues(labelParseUuid, labelCorrelationId).Inc()
 }
 
-func InvalidMessageId(ctx echo.Context, value string, err error) {
-	utils.GetLogFromEcho(ctx).Errorw("Error parsing message id", "error", err, "value", value)
-	validationFailureTotal.WithLabelValues(labelParseUuid, labelMessageId).Inc()
-}
-
 func CloudConnectorRequestError(ctx echo.Context, err error, recipient uuid.UUID) {
 	utils.GetLogFromEcho(ctx).Errorw("Error sending message to cloud connector", "error", err, "recipient", recipient)
 	connectorErrorTotal.Inc()
 }
 
-func CloudConnectorOK(ctx echo.Context, recipient uuid.UUID) {
-	utils.GetLogFromEcho(ctx).Debugw("Received response from cloud connector", "recipient", recipient)
+func CloudConnectorOK(ctx echo.Context, recipient uuid.UUID, messageId *string) {
+	utils.GetLogFromEcho(ctx).Debugw("Received response from cloud connector", "recipient", recipient, "message_id", *messageId)
 	connectorSentTotal.Inc()
 }
 

--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -33,6 +33,7 @@ func Get() *viper.Viper {
 	options.SetDefault("openshift.build.commit", "unknown")
 
 	options.SetDefault("log.level", "debug")
+	options.SetDefault("demo.mode", false)
 
 	options.SetDefault("http.max.body.size", "512KB")
 


### PR DESCRIPTION
adds a little shortcut to make it easier to match a sample upload with a run when doing isolated demos