### PR TITLE
Log the correlation_id under a field named "correlation_id"

### DIFF
--- a/internal/common/utils/logging.go
+++ b/internal/common/utils/logging.go
@@ -102,8 +102,8 @@ func WithRequestId(parent context.Context, requestId string) context.Context {
 	return withKeyValue(parent, "request_id", requestId)
 }
 
-func WithCorrelationId(parent context.Context, requestId string) context.Context {
-	return withKeyValue(parent, "request_id", requestId)
+func WithCorrelationId(parent context.Context, correlationId string) context.Context {
+	return withKeyValue(parent, "correlation_id", correlationId)
 }
 
 func withKeyValue(parent context.Context, key, value string) context.Context {


### PR DESCRIPTION
I believe the correlation_id is getting logged as the request_id.  I think this is going to make it so that the real request_id is overwritten by the correlation_id.