### PR TITLE
add metric for outbound HTTP request duration

### DIFF
--- a/internal/common/instrumentation/histograms.go
+++ b/internal/common/instrumentation/histograms.go
@@ -1,0 +1,36 @@
+package instrumentation
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var outboundHTTPDurationHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name: "outbound_http_duration_seconds",
+	Help: "Time spent waiting for an HTTP response",
+	Buckets: []float64{
+		0.0005,
+		0.001, // 1ms
+		0.002,
+		0.005,
+		0.01, // 10ms
+		0.02,
+		0.05,
+		0.1, // 100 ms
+		0.2,
+		0.5,
+		1.0, // 1s
+		2.0,
+		5.0,
+		10.0, // 10s
+		15.0,
+		20.0,
+		30.0,
+	},
+}, []string{"service"})
+
+func OutboundHTTPDurationTimerFactory(service string) func() *prometheus.Timer {
+	return func() *prometheus.Timer {
+		return prometheus.NewTimer(outboundHTTPDurationHistogram.WithLabelValues(service))
+	}
+}

--- a/internal/validator/handler.go
+++ b/internal/validator/handler.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"playbook-dispatcher/internal/common/config"
 	"playbook-dispatcher/internal/common/constants"
+	commonInstrumentation "playbook-dispatcher/internal/common/instrumentation"
 	kafkaUtils "playbook-dispatcher/internal/common/kafka"
 	messageModel "playbook-dispatcher/internal/common/model/message"
 	"playbook-dispatcher/internal/common/utils"
@@ -29,6 +30,7 @@ var (
 	}
 	ingressResponseTopic    = cfg.GetString("topic.validation.response")
 	dispatcherResponseTopic = cfg.GetString("topic.updates")
+	timerFactory            = commonInstrumentation.OutboundHTTPDurationTimerFactory("storage")
 )
 
 const (
@@ -71,7 +73,7 @@ func (this *handler) handleRequest(
 		this.validationFailed(ctx, err, ingressResponse)
 	}
 
-	res, err := utils.DoGetWithRetry(client, request.URL, cfg.GetInt("storage.retries"))
+	res, err := utils.DoGetWithRetry(client, request.URL, cfg.GetInt("storage.retries"), timerFactory)
 	if err != nil {
 		instrumentation.FetchArchiveError(ctx, err)
 		return


### PR DESCRIPTION
currently only used for archive retrievals from storage but can be expanded easily