### PR TITLE
use the correct context (i.e. not the one that's canceled) when shutt…

### DIFF
--- a/internal/common/utils/misc.go
+++ b/internal/common/utils/misc.go
@@ -20,7 +20,7 @@ func DieOnError(err error) {
 
 func StopServer(ctx context.Context, server *echo.Echo) {
 	if e := server.Shutdown(ctx); e != nil {
-		GetLogFromContext(ctx).Fatal(e)
+		GetLogFromContext(ctx).Error(e)
 	}
 }
 


### PR DESCRIPTION
…ing down the API