### PR TITLE
Support rhc-sat responses in response consumer [RHCLOUD-16814]

### DIFF
--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -52,6 +52,7 @@ func Get() *viper.Viper {
 	options.SetDefault("kafka.retry.backoff.ms", 100)
 
 	options.SetDefault("schema.message.response", "./schema/playbookRunResponse.message.yaml")
+	options.SetDefault("schema.satmessage.response", "./schema/playbookSatRunResponse.message.yaml")
 	options.SetDefault("schema.runner.event", "./schema/ansibleRunnerJobEvent.yaml")
 	options.SetDefault("schema.rhcsat.event", "./schema/rhcsatJobEvent.yaml")
 	options.SetDefault("schema.api.private", "./schema/private.openapi.yaml")

--- a/internal/common/constants/constants.go
+++ b/internal/common/constants/constants.go
@@ -4,6 +4,7 @@ const (
 	HeaderRequestId     = "x-rh-insights-request-id"
 	HeaderCorrelationId = "x-rh-insights-playbook-dispatcher-correlation-id"
 	HeaderIdentity      = "x-rh-identity"
+	HeaderRequestType   = "service"
 
 	HeaderCloudConnectorClientID = "x-rh-cloud-connector-client-id"
 	HeaderCloudConnectorAccount  = "x-rh-cloud-connector-account"

--- a/internal/common/model/db/Run.go
+++ b/internal/common/model/db/Run.go
@@ -9,10 +9,11 @@ import (
 )
 
 const (
-	RunStatusRunning = "running"
-	RunStatusSuccess = "success"
-	RunStatusFailure = "failure"
-	RunStatusTimeout = "timeout"
+	RunStatusRunning  = "running"
+	RunStatusSuccess  = "success"
+	RunStatusFailure  = "failure"
+	RunStatusTimeout  = "timeout"
+	RunStatusCanceled = "canceled"
 )
 
 type Run struct {

--- a/internal/common/model/db/RunHost.go
+++ b/internal/common/model/db/RunHost.go
@@ -13,6 +13,8 @@ type RunHost struct {
 	InventoryID *uuid.UUID `gorm:"type:uuid"`
 	Host        string
 
+	SatSequence *int
+
 	Status string
 	Log    string
 

--- a/internal/common/satellite/sat-test-events1.jsonl
+++ b/internal/common/satellite/sat-test-events1.jsonl
@@ -1,0 +1,3 @@
+{"type": "playbook_run_update", "version": 3, "correlation_id": "0465783c-2e36-4e57-8514-c2cb962d323a", "sequence": 0, "host": "localhost", "console": ""}
+{"type": "playbook_run_update", "version": 3, "correlation_id": "0465783c-2e36-4e57-8514-c2cb962d323a", "sequence": 0, "host": "localhost", "console": ""}
+{"type": "playbook_run_update", "version": 3, "correlation_id": "0465783c-2e36-4e57-8514-c2cb962d323a", "sequence": 0, "host": "localhost", "console": ""}

--- a/internal/common/satellite/sat-test-events2.jsonl
+++ b/internal/common/satellite/sat-test-events2.jsonl
@@ -1,0 +1,3 @@
+{"type": "playbook_run_update", "version": 3, "correlation_id": "0465783c-2e36-4e57-8514-c2cb962d323a", "sequence": 1, "host": "localhost", "console": "localhost | FAILED => {\n    \"changed\": false,\n    \"ping\": \"runtime_error\"\n}"}
+{"type": "playbook_run_finished", "version": 3, "correlation_id": "0465783c-2e36-4e57-8514-c2cb962d323a", "host": "localhost", "status": "failure", "connection_code": 0, "execution_code": 0}
+{"type": "playbook_run_completed", "version": 3, "correlation_id": "0465783c-2e36-4e57-8514-c2cb962d323a", "status": "failure", "satellite_connection_code": 0, "satellite_infrastructure_code": 0}

--- a/internal/common/satellite/sat-test-events3.jsonl
+++ b/internal/common/satellite/sat-test-events3.jsonl
@@ -1,0 +1,2 @@
+{"type": "playbook_run_update", "version": 3, "correlation_id": "0465783c-2e36-4e57-8514-c2cb962d323a", "sequence": 1, "host": "localhost", "console": "localhost | SUCCESS => {\n    \"changed\": false,\n    \"ping\": \"unknown\"\n}"}
+{"type": "playbook_run_finished", "version": 3, "correlation_id": "0465783c-2e36-4e57-8514-c2cb962d323a", "host": "localhost", "status": "canceled", "connection_code": 0, "execution_code": 0}

--- a/internal/common/satellite/sat-test-events4.jsonl
+++ b/internal/common/satellite/sat-test-events4.jsonl
@@ -1,0 +1,4 @@
+{"type": "playbook_run_update", "version": 3, "correlation_id": "0465783c-2e36-4e57-8514-c2cb962d323a", "sequence": 0, "host": "host1", "console": "host1 | SUCCESS => {\n    \"changed\": false,\n    \"ping\": \"pong\"\n}"}
+{"type": "playbook_run_finished", "version": 3, "correlation_id": "0465783c-2e36-4e57-8514-c2cb962d323a", "host": "host1", "status": "success", "connection_code": 0, "execution_code": 0}
+{"type": "playbook_run_update", "version": 3, "correlation_id": "0465783c-2e36-4e57-8514-c2cb962d323a", "sequence": 4, "host": "host2", "console": "host2 | SUCCESS => {\n    \"changed\": false,\n    \"ping\": \"pong\"\n}"}
+{"type": "playbook_run_finished", "version": 3, "correlation_id": "0465783c-2e36-4e57-8514-c2cb962d323a", "host": "host2", "status": "success", "connection_code": 0, "execution_code": 0}

--- a/internal/common/satellite/satellite.go
+++ b/internal/common/satellite/satellite.go
@@ -1,0 +1,49 @@
+package satellite
+
+import (
+	messageModel "playbook-dispatcher/internal/common/model/message"
+	"playbook-dispatcher/internal/common/utils"
+	"sort"
+)
+
+func GetSatHosts(events []messageModel.PlaybookSatRunResponseMessageYamlEventsElem) []string {
+	hosts := make(map[string]interface{})
+
+	for _, event := range events {
+		if event.Host != nil {
+			hosts[*event.Host] = true
+		}
+	}
+
+	keys := utils.MapKeys(hosts)
+	sort.Strings(keys)
+	return keys
+}
+
+type SatHostInfo struct {
+	Sequence int
+	Console  string
+}
+
+func GetSatHostInfo(events []messageModel.PlaybookSatRunResponseMessageYamlEventsElem, host *string) *SatHostInfo {
+	hostInfo := SatHostInfo{}
+	for _, event := range events {
+		if event.Host != nil && *event.Host != *host {
+			continue
+		}
+		if event.Sequence != nil {
+			hostInfo.Sequence = *event.Sequence
+		}
+		if event.Console != nil {
+			hostInfo.Console += *event.Console
+		}
+
+		if event.SatelliteConnectionCode != nil && *event.SatelliteConnectionCode != 0 {
+			hostInfo.Console += *event.SatelliteConnectionError
+		}
+		if event.SatelliteInfrastructureCode != nil && *event.SatelliteInfrastructureCode != 0 {
+			hostInfo.Console += *event.SatelliteInfrastructureError
+		}
+	}
+	return &hostInfo
+}

--- a/internal/common/satellite/satellite_suite_test.go
+++ b/internal/common/satellite/satellite_suite_test.go
@@ -1,0 +1,13 @@
+package satellite
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Satellite Suite")
+}

--- a/internal/common/satellite/satellite_test.go
+++ b/internal/common/satellite/satellite_test.go
@@ -1,0 +1,83 @@
+package satellite
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	messageModel "playbook-dispatcher/internal/common/model/message"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func loadFile(path string) (events []messageModel.PlaybookSatRunResponseMessageYamlEventsElem) {
+	file, err := ioutil.ReadFile(path)
+	Expect(err).ToNot(HaveOccurred())
+
+	lines := strings.Split(string(file), "\n")
+
+	for _, line := range lines {
+		if len(strings.TrimSpace(line)) == 0 {
+			continue
+		}
+
+		event := messageModel.PlaybookSatRunResponseMessageYamlEventsElem{}
+		err = json.Unmarshal([]byte(line), &event)
+		Expect(err).ToNot(HaveOccurred())
+
+		events = append(events, event)
+	}
+
+	return events
+}
+
+var _ = Describe("Satellite", func() {
+	Describe("host", func() {
+		It("determines satellite host from a successful run", func() {
+			events := loadFile("./sat-test-events1.jsonl")
+			hosts := GetSatHosts(events)
+			Expect(hosts).To(HaveLen(1))
+			Expect(hosts[0]).To(Equal("localhost"))
+		})
+
+		It("determines satellite host from a failed run", func() {
+			events := loadFile("./sat-test-events2.jsonl")
+			hosts := GetSatHosts(events)
+			Expect(hosts).To(HaveLen(1))
+			Expect(hosts[0]).To(Equal("localhost"))
+		})
+
+		It("determines satellite host from a cancelled run", func() {
+			events := loadFile("./sat-test-events3.jsonl")
+			hosts := GetSatHosts(events)
+			Expect(hosts).To(HaveLen(1))
+			Expect(hosts[0]).To(Equal("localhost"))
+		})
+
+		It("determines satellite hosts from a multi-host run", func() {
+			events := loadFile("./sat-test-events4.jsonl")
+			hosts := GetSatHosts(events)
+			Expect(hosts).To(HaveLen(2))
+			Expect(hosts[0]).To(Equal("host1"))
+			Expect(hosts[1]).To(Equal("host2"))
+		})
+	})
+
+	Describe("satHostInfo", func() {
+		It("determines satHostinfo from a run", func() {
+			events := loadFile("./sat-test-events2.jsonl")
+			host := "localhost"
+			satHostInfo := GetSatHostInfo(events, &host)
+			Expect(satHostInfo.Sequence).To(Equal(1))
+			Expect(satHostInfo.Console).To(Equal("localhost | FAILED => {\n    \"changed\": false,\n    \"ping\": \"runtime_error\"\n}"))
+		})
+
+		It("determines correct satHostinfo from a multi-host run", func() {
+			events := loadFile("./sat-test-events4.jsonl")
+			host := "host2"
+			satHostInfo := GetSatHostInfo(events, &host)
+			Expect(satHostInfo.Sequence).To(Equal(4))
+			Expect(satHostInfo.Console).To(Equal("host2 | SUCCESS => {\n    \"changed\": false,\n    \"ping\": \"pong\"\n}"))
+		})
+	})
+})

--- a/internal/common/utils/misc.go
+++ b/internal/common/utils/misc.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/url"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/ghodss/yaml"
 	"github.com/labstack/echo/v4"
+	"github.com/qri-io/jsonschema"
+	"github.com/spf13/viper"
 )
 
 func DieOnError(err error) {
@@ -91,4 +95,17 @@ func SetRequestContextValue(c echo.Context, key interface{}, value interface{}) 
 	req := c.Request()
 	c.SetRequest(req.WithContext(context.WithValue(req.Context(), key, value)))
 	return c
+}
+
+func LoadSchemas(cfg *viper.Viper, schemaNames []string) (schemas []*jsonschema.Schema) {
+	for _, schemaName := range schemaNames {
+		var schema jsonschema.Schema
+		file, err := ioutil.ReadFile(cfg.GetString(schemaName))
+		DieOnError(err)
+		err = yaml.Unmarshal(file, &schema)
+		DieOnError(err)
+
+		schemas = append(schemas, &schema)
+	}
+	return
 }

--- a/internal/validator/main.go
+++ b/internal/validator/main.go
@@ -2,14 +2,11 @@ package validator
 
 import (
 	"context"
-	"io/ioutil"
 	"playbook-dispatcher/internal/common/kafka"
 	"playbook-dispatcher/internal/common/utils"
 	"playbook-dispatcher/internal/validator/instrumentation"
 	"sync"
 
-	"github.com/ghodss/yaml"
-	"github.com/qri-io/jsonschema"
 	"github.com/spf13/viper"
 )
 
@@ -26,18 +23,8 @@ func Start(
 	ready, live *utils.ProbeHandler,
 	wg *sync.WaitGroup,
 ) {
-	var schemas []*jsonschema.Schema
 	var schemaNames = []string{"schema.runner.event", "schema.rhcsat.event"}
-
-	for _, schemaName := range schemaNames {
-		var schema jsonschema.Schema
-		file, err := ioutil.ReadFile(cfg.GetString(schemaName))
-		utils.DieOnError(err)
-		err = yaml.Unmarshal(file, &schema)
-		utils.DieOnError(err)
-
-		schemas = append(schemas, &schema)
-	}
+	schemas := utils.LoadSchemas(cfg, schemaNames)
 
 	storageConnectorConcurrency := cfg.GetInt("storage.max.concurrency")
 	kafkaTimeout := cfg.GetInt("kafka.timeout")

--- a/migrations/006_add-sat-seq.down.sql
+++ b/migrations/006_add-sat-seq.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE run_hosts DROP COLUMN sat_sequence;

--- a/migrations/006_add-sat-seq.up.sql
+++ b/migrations/006_add-sat-seq.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE run_hosts ADD COLUMN sat_sequence smallint default NULL;

--- a/migrations/007_alter_runs_status.up.sql
+++ b/migrations/007_alter_runs_status.up.sql
@@ -1,0 +1,1 @@
+ALTER TYPE runs_status ADD VALUE 'canceled';

--- a/schema/public.openapi.yaml
+++ b/schema/public.openapi.yaml
@@ -122,6 +122,7 @@ components:
         - success
         - failure
         - timeout
+        - canceled
 
     CreatedAt:
       description: A timestamp when the entry was created
@@ -282,6 +283,7 @@ components:
         - success
         - failure
         - timeout
+        - canceled
 
     ServiceNullable:
       nullable: true

--- a/schema/run.event.yaml
+++ b/schema/run.event.yaml
@@ -37,6 +37,7 @@ properties:
           - success
           - failure
           - timeout
+          - canceled
       timeout:
         type: integer
         minimum: 0


### PR DESCRIPTION
## What?
Support for parsing the satellite messages produced by the playbook-dispatcher validator.
Stores the data from the satellite runs in the database.
This PR also contains 2 DB migrations. One to add the new `satellite sequence number` column and another one to add the new `canceled` run status. Both migrations are for the `run_status` table.

## Why?
This will help with the dispatching of satellite playbook via the API.
The API will need to read the data from the satellite runs.
## How?

1. dispatcher-validator produces a validated satellite message to the `responses` kafka topic with the header `playbook-sat` (already implemented in a previous PR).
2. dispatcher-response-consumer reads events from the `responses` topic.
3. response-consumer sees the `playbook-sat` message header and determines the event to be from a satellite host.
4. response-consumer determines the status of the run which can be one of: `running`,`success`,`failure` and `canceled`.
5. response-consumer stores run information such as `console log`, `satellite sequence number`, `status` etc. from the message to the DB.
6. Both DB tables are updated (`runs` - stores whole playbook run info, `run_hosts` - stores info on each individual hosts).

## Testing?
The following tests were added:

- update of run status based on successful satellite events
- update of run status based on failed satellite events
- update of run status based on canceled satellite events
- update of run status of multiple hosts involved in a single run
- copy `satellite_connection_error` to the `console log` field when the `satellite_connection_code` is not `0`
- copy `satellite_infrastructure_error` to the `console log` field when the `satellite_infrastructure_code` is not `0`

- determining of satellite hosts from a successful run
- determining of satellite hosts from a failed run
- determining of satellite hosts from a canceled run
- determining of satellite hosts from a multi-host run

## Screenshots (optional)
## Anything Else?