### PR TITLE
fix incorect dereferencing of host attributes in a loop

### DIFF
--- a/internal/api/controllers/public/runHostsList.go
+++ b/internal/api/controllers/public/runHostsList.go
@@ -113,9 +113,9 @@ func (this *controllers) ApiRunHostsList(ctx echo.Context, params ApiRunHostsLis
 		for _, field := range fields {
 			switch field {
 			case fieldHost:
-				runHost.Host = &host.Host
+				runHost.Host = utils.StringRef(host.Host)
 			case fieldStdout:
-				runHost.Stdout = &host.Log
+				runHost.Stdout = utils.StringRef(host.Log)
 			case fieldStatus:
 				runHost.Status = &runStatus
 			case fieldRun:


### PR DESCRIPTION
In golang we must avoid using the & operator on a loop variable - otherwise all the items in a collection end up holding the same reference