### PR TITLE
RHCLOUD-17173 provide connection status resource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ generate-messages:
 generate-cloud-connector:
 	curl -s ${CLOUD_CONNECTOR_SCHEMA} -o cloud-connector.json
 	json2yaml cloud-connector.json cloud-connector.yaml
-	~/go/bin/oapi-codegen -generate client,types -package connectors -exclude-tags connection -o internal/api/connectors/cloudConnector.gen.go cloud-connector.yaml
+	~/go/bin/oapi-codegen -generate client,types -package connectors -o internal/api/connectors/cloudConnector.gen.go cloud-connector.yaml
 	rm cloud-connector.json cloud-connector.yaml
 
 generate-rbac:

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,9 @@ test: migrate-db
 sample_request:
 	curl -v -H "content-type: application/json" -H "Authorization: PSK xwKhCUzgJ8" -d "@examples/payload.json" http://localhost:8000/internal/dispatch
 
+sample_recipient_status:
+	curl -v -H "content-type: application/json" -H "Authorization: PSK xwKhCUzgJ8" -d '[{"recipient": "35720ecb-bc23-4b06-a8cd-f0c264edf2c1", "org_id": "5318290"}]' http://localhost:8000/internal/v2/recipients/status
+
 sample_upload:
 	curl -v -F "file=@examples/events-success.jsonl;type=application/vnd.redhat.playbook.v1+jsonl" -H "x-rh-identity: eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMDAwMDAwMSIsICJ0eXBlIjogIlN5c3RlbSIsICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjAwMDAwMSJ9fX0=" -H "x-rh-request_id: 380b4a04-7eae-4dff-a0b8-6e1af9186df0" http://localhost:8080/api/ingress/v1/upload
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,40 @@ The keys are configured via environment variables in form of `PSK_AUTH_<service 
 PSK_AUTH_REMEDIATIONS=xwKhCUzgJ8 ./app run
 ```
 
+### Recipient status
+
+One of the operations available in the internal API is the recipient status.
+This operation allows the client to obtain connection information for a given set of recipients.
+
+Sample request:
+```
+POST /internal/v2/recipients/status
+[
+    {
+        "recipient": "35720ecb-bc23-4b06-a8cd-f0c264edf2c1",
+        "org_id": "5318290"
+    }, {
+        "recipient": "73dca8b6-cc11-4954-8f6c-9ecc732ec212",
+        "org_id": "5318290"
+    }
+]
+```
+
+Sample response:
+```
+[
+    {
+        "recipient": "35720ecb-bc23-4b06-a8cd-f0c264edf2c1",
+        "org_id": "5318290",
+        "connected": true
+    }, {
+        "recipient": "73dca8b6-cc11-4954-8f6c-9ecc732ec212",
+        "org_id": "5318290",
+        "connected": false
+    }
+]
+```
+
 See [API schema](./schema/private.openapi.yaml) for more details.
 
 ## Event interface

--- a/internal/api/connectors/cloudConnector.gen.go
+++ b/internal/api/connectors/cloudConnector.gen.go
@@ -14,8 +14,67 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/deepmap/oapi-codegen/pkg/runtime"
 	"github.com/pkg/errors"
 )
+
+// ConnectionDisconnectRequest defines model for ConnectionDisconnectRequest.
+type ConnectionDisconnectRequest struct {
+	Account *string `json:"account,omitempty"`
+	Message *string `json:"message,omitempty"`
+	NodeId  *string `json:"node_id,omitempty"`
+}
+
+// ConnectionListAccountResponse defines model for ConnectionListAccountResponse.
+type ConnectionListAccountResponse struct {
+	// Embedded struct due to allOf(#/components/schemas/PaginatedResponseMeta)
+	PaginatedResponseMeta `yaml:",inline"`
+	// Embedded struct due to allOf(#/components/schemas/PaginatedResponseLinks)
+	PaginatedResponseLinks `yaml:",inline"`
+}
+
+// ConnectionListResponse defines model for ConnectionListResponse.
+type ConnectionListResponse struct {
+	// Embedded struct due to allOf(#/components/schemas/PaginatedResponseMeta)
+	PaginatedResponseMeta `yaml:",inline"`
+	// Embedded struct due to allOf(#/components/schemas/PaginatedResponseLinks)
+	PaginatedResponseLinks `yaml:",inline"`
+}
+
+// ConnectionPingResponse defines model for ConnectionPingResponse.
+type ConnectionPingResponse struct {
+	Payload *Payload          `json:"payload,omitempty"`
+	Status  *ConnectionStatus `json:"status,omitempty"`
+}
+
+// ConnectionReconnectRequest defines model for ConnectionReconnectRequest.
+type ConnectionReconnectRequest struct {
+	Account *string `json:"account,omitempty"`
+	Delay   *int    `json:"delay,omitempty"`
+	Message *string `json:"message,omitempty"`
+	NodeId  *string `json:"node_id,omitempty"`
+}
+
+// ConnectionStatus defines model for ConnectionStatus.
+type ConnectionStatus string
+
+// List of ConnectionStatus
+const (
+	ConnectionStatus_connected    ConnectionStatus = "connected"
+	ConnectionStatus_disconnected ConnectionStatus = "disconnected"
+)
+
+// ConnectionStatusRequest defines model for ConnectionStatusRequest.
+type ConnectionStatusRequest struct {
+	Account *string `json:"account,omitempty"`
+	NodeId  *string `json:"node_id,omitempty"`
+}
+
+// ConnectionStatusResponse defines model for ConnectionStatusResponse.
+type ConnectionStatusResponse struct {
+	Dispatchers *map[string]interface{} `json:"dispatchers,omitempty"`
+	Status      *ConnectionStatus       `json:"status,omitempty"`
+}
 
 // MessageRequest defines model for MessageRequest.
 type MessageRequest struct {
@@ -36,8 +95,90 @@ type MessageResponse struct {
 	Id *string `json:"id,omitempty"`
 }
 
+// PaginatedResponseLinks defines model for PaginatedResponseLinks.
+type PaginatedResponseLinks struct {
+	Links *struct {
+		First *string `json:"first,omitempty"`
+		Last  *string `json:"last,omitempty"`
+		Next  *string `json:"next,omitempty"`
+		Prev  *string `json:"prev,omitempty"`
+	} `json:"links,omitempty"`
+}
+
+// PaginatedResponseMeta defines model for PaginatedResponseMeta.
+type PaginatedResponseMeta struct {
+	Meta *struct {
+		Count *int `json:"count,omitempty"`
+	} `json:"meta,omitempty"`
+}
+
+// Payload defines model for Payload.
+type Payload struct {
+	Account      *string                 `json:"account,omitempty"`
+	Code         *int                    `json:"code,omitempty"`
+	InResponseTo *string                 `json:"in_response_to,omitempty"`
+	MessageId    *string                 `json:"message_id,omitempty"`
+	MessageType  *string                 `json:"message_type,omitempty"`
+	Payload      *map[string]interface{} `json:"payload,omitempty"`
+	Sender       *string                 `json:"sender,omitempty"`
+	Serial       *int                    `json:"serial,omitempty"`
+}
+
+// AccountID defines model for AccountID.
+type AccountID string
+
+// Limit defines model for Limit.
+type Limit int
+
+// Offset defines model for Offset.
+type Offset int
+
+// GetConnectionParams defines parameters for GetConnection.
+type GetConnectionParams struct {
+
+	// limit
+	Limit *Limit `json:"limit,omitempty"`
+
+	// offset
+	Offset *Offset `json:"offset,omitempty"`
+}
+
+// PostConnectionDisconnectJSONBody defines parameters for PostConnectionDisconnect.
+type PostConnectionDisconnectJSONBody ConnectionDisconnectRequest
+
+// PostConnectionPingJSONBody defines parameters for PostConnectionPing.
+type PostConnectionPingJSONBody ConnectionStatusRequest
+
+// PostConnectionReconnectJSONBody defines parameters for PostConnectionReconnect.
+type PostConnectionReconnectJSONBody ConnectionReconnectRequest
+
+// PostConnectionStatusJSONBody defines parameters for PostConnectionStatus.
+type PostConnectionStatusJSONBody ConnectionStatusRequest
+
+// GetConnectionAccountParams defines parameters for GetConnectionAccount.
+type GetConnectionAccountParams struct {
+
+	// limit
+	Limit *Limit `json:"limit,omitempty"`
+
+	// offset
+	Offset *Offset `json:"offset,omitempty"`
+}
+
 // PostMessageJSONBody defines parameters for PostMessage.
 type PostMessageJSONBody MessageRequest
+
+// PostConnectionDisconnectRequestBody defines body for PostConnectionDisconnect for application/json ContentType.
+type PostConnectionDisconnectJSONRequestBody PostConnectionDisconnectJSONBody
+
+// PostConnectionPingRequestBody defines body for PostConnectionPing for application/json ContentType.
+type PostConnectionPingJSONRequestBody PostConnectionPingJSONBody
+
+// PostConnectionReconnectRequestBody defines body for PostConnectionReconnect for application/json ContentType.
+type PostConnectionReconnectJSONRequestBody PostConnectionReconnectJSONBody
+
+// PostConnectionStatusRequestBody defines body for PostConnectionStatus for application/json ContentType.
+type PostConnectionStatusJSONRequestBody PostConnectionStatusJSONBody
 
 // PostMessageRequestBody defines body for PostMessage for application/json ContentType.
 type PostMessageJSONRequestBody PostMessageJSONBody
@@ -168,10 +309,186 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 
 // The interface specification for the client above.
 type ClientInterface interface {
+	// GetConnection request
+	GetConnection(ctx context.Context, params *GetConnectionParams) (*http.Response, error)
+
+	// PostConnectionDisconnect request  with any body
+	PostConnectionDisconnectWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error)
+
+	PostConnectionDisconnect(ctx context.Context, body PostConnectionDisconnectJSONRequestBody) (*http.Response, error)
+
+	// PostConnectionPing request  with any body
+	PostConnectionPingWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error)
+
+	PostConnectionPing(ctx context.Context, body PostConnectionPingJSONRequestBody) (*http.Response, error)
+
+	// PostConnectionReconnect request  with any body
+	PostConnectionReconnectWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error)
+
+	PostConnectionReconnect(ctx context.Context, body PostConnectionReconnectJSONRequestBody) (*http.Response, error)
+
+	// PostConnectionStatus request  with any body
+	PostConnectionStatusWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error)
+
+	PostConnectionStatus(ctx context.Context, body PostConnectionStatusJSONRequestBody) (*http.Response, error)
+
+	// GetConnectionAccount request
+	GetConnectionAccount(ctx context.Context, account AccountID, params *GetConnectionAccountParams) (*http.Response, error)
+
 	// PostMessage request  with any body
 	PostMessageWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error)
 
 	PostMessage(ctx context.Context, body PostMessageJSONRequestBody) (*http.Response, error)
+}
+
+func (c *Client) GetConnection(ctx context.Context, params *GetConnectionParams) (*http.Response, error) {
+	req, err := NewGetConnectionRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostConnectionDisconnectWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := NewPostConnectionDisconnectRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostConnectionDisconnect(ctx context.Context, body PostConnectionDisconnectJSONRequestBody) (*http.Response, error) {
+	req, err := NewPostConnectionDisconnectRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostConnectionPingWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := NewPostConnectionPingRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostConnectionPing(ctx context.Context, body PostConnectionPingJSONRequestBody) (*http.Response, error) {
+	req, err := NewPostConnectionPingRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostConnectionReconnectWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := NewPostConnectionReconnectRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostConnectionReconnect(ctx context.Context, body PostConnectionReconnectJSONRequestBody) (*http.Response, error) {
+	req, err := NewPostConnectionReconnectRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostConnectionStatusWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := NewPostConnectionStatusRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostConnectionStatus(ctx context.Context, body PostConnectionStatusJSONRequestBody) (*http.Response, error) {
+	req, err := NewPostConnectionStatusRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetConnectionAccount(ctx context.Context, account AccountID, params *GetConnectionAccountParams) (*http.Response, error) {
+	req, err := NewGetConnectionAccountRequest(c.Server, account, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
 }
 
 func (c *Client) PostMessageWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error) {
@@ -202,6 +519,295 @@ func (c *Client) PostMessage(ctx context.Context, body PostMessageJSONRequestBod
 		}
 	}
 	return c.Client.Do(req)
+}
+
+// NewGetConnectionRequest generates requests for GetConnection
+func NewGetConnectionRequest(server string, params *GetConnectionParams) (*http.Request, error) {
+	var err error
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/connection")
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryUrl.Query()
+
+	if params.Limit != nil {
+
+		if queryFrag, err := runtime.StyleParam("form", true, "limit", *params.Limit); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.Offset != nil {
+
+		if queryFrag, err := runtime.StyleParam("form", true, "offset", *params.Offset); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryUrl.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPostConnectionDisconnectRequest calls the generic PostConnectionDisconnect builder with application/json body
+func NewPostConnectionDisconnectRequest(server string, body PostConnectionDisconnectJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostConnectionDisconnectRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPostConnectionDisconnectRequestWithBody generates requests for PostConnectionDisconnect with any type of body
+func NewPostConnectionDisconnectRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/connection/disconnect")
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryUrl.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+	return req, nil
+}
+
+// NewPostConnectionPingRequest calls the generic PostConnectionPing builder with application/json body
+func NewPostConnectionPingRequest(server string, body PostConnectionPingJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostConnectionPingRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPostConnectionPingRequestWithBody generates requests for PostConnectionPing with any type of body
+func NewPostConnectionPingRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/connection/ping")
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryUrl.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+	return req, nil
+}
+
+// NewPostConnectionReconnectRequest calls the generic PostConnectionReconnect builder with application/json body
+func NewPostConnectionReconnectRequest(server string, body PostConnectionReconnectJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostConnectionReconnectRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPostConnectionReconnectRequestWithBody generates requests for PostConnectionReconnect with any type of body
+func NewPostConnectionReconnectRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/connection/reconnect")
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryUrl.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+	return req, nil
+}
+
+// NewPostConnectionStatusRequest calls the generic PostConnectionStatus builder with application/json body
+func NewPostConnectionStatusRequest(server string, body PostConnectionStatusJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostConnectionStatusRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPostConnectionStatusRequestWithBody generates requests for PostConnectionStatus with any type of body
+func NewPostConnectionStatusRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/connection/status")
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryUrl.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+	return req, nil
+}
+
+// NewGetConnectionAccountRequest generates requests for GetConnectionAccount
+func NewGetConnectionAccountRequest(server string, account AccountID, params *GetConnectionAccountParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "account", account)
+	if err != nil {
+		return nil, err
+	}
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/connection/%s", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryUrl.Query()
+
+	if params.Limit != nil {
+
+		if queryFrag, err := runtime.StyleParam("form", true, "limit", *params.Limit); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.Offset != nil {
+
+		if queryFrag, err := runtime.StyleParam("form", true, "offset", *params.Offset); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryUrl.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
 }
 
 // NewPostMessageRequest calls the generic PostMessage builder with application/json body
@@ -272,10 +878,166 @@ func WithBaseURL(baseURL string) ClientOption {
 
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
+	// GetConnection request
+	GetConnectionWithResponse(ctx context.Context, params *GetConnectionParams) (*GetConnectionResponse, error)
+
+	// PostConnectionDisconnect request  with any body
+	PostConnectionDisconnectWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*PostConnectionDisconnectResponse, error)
+
+	PostConnectionDisconnectWithResponse(ctx context.Context, body PostConnectionDisconnectJSONRequestBody) (*PostConnectionDisconnectResponse, error)
+
+	// PostConnectionPing request  with any body
+	PostConnectionPingWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*PostConnectionPingResponse, error)
+
+	PostConnectionPingWithResponse(ctx context.Context, body PostConnectionPingJSONRequestBody) (*PostConnectionPingResponse, error)
+
+	// PostConnectionReconnect request  with any body
+	PostConnectionReconnectWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*PostConnectionReconnectResponse, error)
+
+	PostConnectionReconnectWithResponse(ctx context.Context, body PostConnectionReconnectJSONRequestBody) (*PostConnectionReconnectResponse, error)
+
+	// PostConnectionStatus request  with any body
+	PostConnectionStatusWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*PostConnectionStatusResponse, error)
+
+	PostConnectionStatusWithResponse(ctx context.Context, body PostConnectionStatusJSONRequestBody) (*PostConnectionStatusResponse, error)
+
+	// GetConnectionAccount request
+	GetConnectionAccountWithResponse(ctx context.Context, account AccountID, params *GetConnectionAccountParams) (*GetConnectionAccountResponse, error)
+
 	// PostMessage request  with any body
 	PostMessageWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*PostMessageResponse, error)
 
 	PostMessageWithResponse(ctx context.Context, body PostMessageJSONRequestBody) (*PostMessageResponse, error)
+}
+
+type GetConnectionResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ConnectionListResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r GetConnectionResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetConnectionResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostConnectionDisconnectResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r PostConnectionDisconnectResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostConnectionDisconnectResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostConnectionPingResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ConnectionPingResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r PostConnectionPingResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostConnectionPingResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostConnectionReconnectResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r PostConnectionReconnectResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostConnectionReconnectResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostConnectionStatusResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ConnectionStatusResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r PostConnectionStatusResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostConnectionStatusResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetConnectionAccountResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ConnectionListAccountResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r GetConnectionAccountResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetConnectionAccountResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
 }
 
 type PostMessageResponse struct {
@@ -300,6 +1062,92 @@ func (r PostMessageResponse) StatusCode() int {
 	return 0
 }
 
+// GetConnectionWithResponse request returning *GetConnectionResponse
+func (c *ClientWithResponses) GetConnectionWithResponse(ctx context.Context, params *GetConnectionParams) (*GetConnectionResponse, error) {
+	rsp, err := c.GetConnection(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetConnectionResponse(rsp)
+}
+
+// PostConnectionDisconnectWithBodyWithResponse request with arbitrary body returning *PostConnectionDisconnectResponse
+func (c *ClientWithResponses) PostConnectionDisconnectWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*PostConnectionDisconnectResponse, error) {
+	rsp, err := c.PostConnectionDisconnectWithBody(ctx, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostConnectionDisconnectResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostConnectionDisconnectWithResponse(ctx context.Context, body PostConnectionDisconnectJSONRequestBody) (*PostConnectionDisconnectResponse, error) {
+	rsp, err := c.PostConnectionDisconnect(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostConnectionDisconnectResponse(rsp)
+}
+
+// PostConnectionPingWithBodyWithResponse request with arbitrary body returning *PostConnectionPingResponse
+func (c *ClientWithResponses) PostConnectionPingWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*PostConnectionPingResponse, error) {
+	rsp, err := c.PostConnectionPingWithBody(ctx, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostConnectionPingResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostConnectionPingWithResponse(ctx context.Context, body PostConnectionPingJSONRequestBody) (*PostConnectionPingResponse, error) {
+	rsp, err := c.PostConnectionPing(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostConnectionPingResponse(rsp)
+}
+
+// PostConnectionReconnectWithBodyWithResponse request with arbitrary body returning *PostConnectionReconnectResponse
+func (c *ClientWithResponses) PostConnectionReconnectWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*PostConnectionReconnectResponse, error) {
+	rsp, err := c.PostConnectionReconnectWithBody(ctx, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostConnectionReconnectResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostConnectionReconnectWithResponse(ctx context.Context, body PostConnectionReconnectJSONRequestBody) (*PostConnectionReconnectResponse, error) {
+	rsp, err := c.PostConnectionReconnect(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostConnectionReconnectResponse(rsp)
+}
+
+// PostConnectionStatusWithBodyWithResponse request with arbitrary body returning *PostConnectionStatusResponse
+func (c *ClientWithResponses) PostConnectionStatusWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*PostConnectionStatusResponse, error) {
+	rsp, err := c.PostConnectionStatusWithBody(ctx, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostConnectionStatusResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostConnectionStatusWithResponse(ctx context.Context, body PostConnectionStatusJSONRequestBody) (*PostConnectionStatusResponse, error) {
+	rsp, err := c.PostConnectionStatus(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostConnectionStatusResponse(rsp)
+}
+
+// GetConnectionAccountWithResponse request returning *GetConnectionAccountResponse
+func (c *ClientWithResponses) GetConnectionAccountWithResponse(ctx context.Context, account AccountID, params *GetConnectionAccountParams) (*GetConnectionAccountResponse, error) {
+	rsp, err := c.GetConnectionAccount(ctx, account, params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetConnectionAccountResponse(rsp)
+}
+
 // PostMessageWithBodyWithResponse request with arbitrary body returning *PostMessageResponse
 func (c *ClientWithResponses) PostMessageWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*PostMessageResponse, error) {
 	rsp, err := c.PostMessageWithBody(ctx, contentType, body)
@@ -315,6 +1163,148 @@ func (c *ClientWithResponses) PostMessageWithResponse(ctx context.Context, body 
 		return nil, err
 	}
 	return ParsePostMessageResponse(rsp)
+}
+
+// ParseGetConnectionResponse parses an HTTP response from a GetConnectionWithResponse call
+func ParseGetConnectionResponse(rsp *http.Response) (*GetConnectionResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetConnectionResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ConnectionListResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostConnectionDisconnectResponse parses an HTTP response from a PostConnectionDisconnectWithResponse call
+func ParsePostConnectionDisconnectResponse(rsp *http.Response) (*PostConnectionDisconnectResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostConnectionDisconnectResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	}
+
+	return response, nil
+}
+
+// ParsePostConnectionPingResponse parses an HTTP response from a PostConnectionPingWithResponse call
+func ParsePostConnectionPingResponse(rsp *http.Response) (*PostConnectionPingResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostConnectionPingResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ConnectionPingResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostConnectionReconnectResponse parses an HTTP response from a PostConnectionReconnectWithResponse call
+func ParsePostConnectionReconnectResponse(rsp *http.Response) (*PostConnectionReconnectResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostConnectionReconnectResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	}
+
+	return response, nil
+}
+
+// ParsePostConnectionStatusResponse parses an HTTP response from a PostConnectionStatusWithResponse call
+func ParsePostConnectionStatusResponse(rsp *http.Response) (*PostConnectionStatusResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostConnectionStatusResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ConnectionStatusResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetConnectionAccountResponse parses an HTTP response from a GetConnectionAccountWithResponse call
+func ParseGetConnectionAccountResponse(rsp *http.Response) (*GetConnectionAccountResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetConnectionAccountResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ConnectionListAccountResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
 }
 
 // ParsePostMessageResponse parses an HTTP response from a PostMessageWithResponse call

--- a/internal/api/connectors/cloudConnector.go
+++ b/internal/api/connectors/cloudConnector.go
@@ -128,7 +128,7 @@ func (this *cloudConnectorClientImpl) SendCloudConnectorRequest(
 	}
 
 	if res.JSON201 == nil {
-		return nil, false, fmt.Errorf(`unexpected status code "%d" or content type "%s"`, res.HTTPResponse.StatusCode, res.HTTPResponse.Header.Get("content-type"))
+		return nil, false, unexpectedResponse(res.HTTPResponse)
 	}
 
 	return res.JSON201.Id, false, nil
@@ -158,7 +158,7 @@ func (this *cloudConnectorClientImpl) GetConnectionStatus(
 	}
 
 	if res.JSON200 == nil {
-		return "", fmt.Errorf(`unexpected status code "%d" or content type "%s"`, res.HTTPResponse.StatusCode, res.HTTPResponse.Header.Get("content-type"))
+		return "", unexpectedResponse(res.HTTPResponse)
 	}
 
 	return *res.JSON200.Status, nil

--- a/internal/api/connectors/cloudConnector.go
+++ b/internal/api/connectors/cloudConnector.go
@@ -20,10 +20,13 @@ const basePath = "/api/cloud-connector/v1/"
 
 var cloudConnectorDirective = "rhc-worker-playbook"
 
-type accountKeyType int
+type tenantKeyType int
 
-// used to pass account down to request editor (to set headers)
-const accountKey accountKeyType = iota
+// used to pass account, org_id down to request editor (to set headers)
+const (
+	accountKey = iota
+	orgIDKey   = iota
+)
 
 type CloudConnectorClient interface {
 	SendCloudConnectorRequest(
@@ -33,6 +36,13 @@ type CloudConnectorClient interface {
 		correlationId uuid.UUID,
 		url string,
 	) (*string, bool, error)
+
+	GetConnectionStatus(
+		ctx context.Context,
+		account string,
+		orgID string,
+		recipient string,
+	) (ConnectionStatus, error)
 }
 
 type cloudConnectorClientImpl struct {
@@ -52,6 +62,11 @@ func NewConnectorClientWithHttpRequestDoer(cfg *viper.Viper, doer HttpRequestDoe
 				req.Header.Set(constants.HeaderCloudConnectorClientID, cfg.GetString("cloud.connector.client.id"))
 				req.Header.Set(constants.HeaderCloudConnectorPSK, cfg.GetString("cloud.connector.psk"))
 				req.Header.Set(constants.HeaderCloudConnectorAccount, ctx.Value(accountKey).(string))
+
+				if orgID := ctx.Value(orgIDKey); orgID != nil {
+					req.Header.Set(constants.HeaderCloudConnectorOrgID, ctx.Value(orgIDKey).(string))
+				}
+
 				return nil
 			},
 		},
@@ -117,4 +132,34 @@ func (this *cloudConnectorClientImpl) SendCloudConnectorRequest(
 	}
 
 	return res.JSON201.Id, false, nil
+}
+
+func (this *cloudConnectorClientImpl) GetConnectionStatus(
+	ctx context.Context,
+	account string,
+	orgID string,
+	recipient string,
+) (status ConnectionStatus, err error) {
+	ctx = context.WithValue(ctx, accountKey, account)
+	ctx = context.WithValue(ctx, orgIDKey, orgID)
+
+	utils.GetLogFromContext(ctx).Debugw("Sending Cloud Connector status request",
+		"account", account,
+		"recipient", recipient,
+	)
+
+	res, err := this.client.PostConnectionStatusWithResponse(ctx, PostConnectionStatusJSONRequestBody{
+		Account: &account,
+		NodeId:  &recipient,
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	if res.JSON200 == nil {
+		return "", fmt.Errorf(`unexpected status code "%d" or content type "%s"`, res.HTTPResponse.StatusCode, res.HTTPResponse.Header.Get("content-type"))
+	}
+
+	return *res.JSON200.Status, nil
 }

--- a/internal/api/connectors/cloudConnector.mock.go
+++ b/internal/api/connectors/cloudConnector.mock.go
@@ -23,3 +23,16 @@ func (this *cloudConnectorClientMock) SendCloudConnectorRequest(
 	id := uuid.New().String()
 	return &id, false, nil
 }
+
+func (this *cloudConnectorClientMock) GetConnectionStatus(
+	ctx context.Context,
+	account string,
+	orgID string,
+	recipient string,
+) (ConnectionStatus, error) {
+	if orgID == "5318290" && recipient == "411cb203-f8c9-480e-ba20-1efbc74e3a33" {
+		return ConnectionStatus_disconnected, nil
+	}
+
+	return ConnectionStatus_connected, nil
+}

--- a/internal/api/connectors/errors.go
+++ b/internal/api/connectors/errors.go
@@ -1,0 +1,10 @@
+package connectors
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func unexpectedResponse(res *http.Response) error {
+	return fmt.Errorf(`unexpected status code "%d" or content type "%s"`, res.StatusCode, res.Header.Get("content-type"))
+}

--- a/internal/api/controllers/private/factory.go
+++ b/internal/api/controllers/private/factory.go
@@ -3,6 +3,7 @@ package private
 import (
 	"fmt"
 	"playbook-dispatcher/internal/api/connectors"
+	"playbook-dispatcher/internal/api/connectors/tenants"
 	"playbook-dispatcher/internal/common/config"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -18,6 +19,7 @@ func CreateController(database *gorm.DB, cloudConnectorClient connectors.CloudCo
 			cloudConnectorClient: cloudConnectorClient,
 			config:               config,
 			rateLimiter:          getRateLimiter(config),
+			translator:           tenants.NewMockTenantIDTranslator(),
 		},
 	}
 }
@@ -28,6 +30,7 @@ type controllers struct {
 	cloudConnectorClient connectors.CloudConnectorClient
 	config               *viper.Viper
 	rateLimiter          *rate.Limiter
+	translator           tenants.TenantIDTranslator
 }
 
 // workaround for https://github.com/deepmap/oapi-codegen/issues/42

--- a/internal/api/controllers/private/recipientStatus.go
+++ b/internal/api/controllers/private/recipientStatus.go
@@ -1,0 +1,62 @@
+package private
+
+import (
+	"fmt"
+	"net/http"
+	"playbook-dispatcher/internal/api/connectors"
+	"playbook-dispatcher/internal/common/utils"
+
+	"github.com/labstack/echo/v4"
+)
+
+func (this *controllers) ApiInternalV2RecipientsStatus(ctx echo.Context) error {
+	var input []RecipientWithOrg
+
+	err := utils.ReadRequestBody(ctx, &input)
+	if err != nil {
+		utils.GetLogFromEcho(ctx).Error(err)
+		return ctx.NoContent(http.StatusBadRequest)
+	}
+
+	// translate org_id to EAN for Cloud Connector
+	// TODO: this will go away in the future
+	orgToEAN := make(map[string]string)
+
+	for _, recipient := range input {
+		orgId := string(recipient.OrgId)
+		if _, ok := orgToEAN[orgId]; !ok {
+			ean, err := this.translator.OrgIDToEAN(ctx.Request().Context(), orgId)
+
+			if err != nil {
+				utils.GetLogFromEcho(ctx).Error(err)
+				return ctx.NoContent(http.StatusInternalServerError)
+			}
+
+			if ean == nil {
+				utils.GetLogFromEcho(ctx).Error(fmt.Errorf("Anemic tenant not supported: %s", orgId))
+				return ctx.NoContent(http.StatusInternalServerError)
+			}
+
+			orgToEAN[orgId] = *ean
+		}
+	}
+
+	// get connection status from Cloud Connector
+	results := make([]RecipientStatus, len(input))
+	for i, recipient := range input {
+		account := orgToEAN[string(recipient.OrgId)]
+
+		status, err := this.cloudConnectorClient.GetConnectionStatus(ctx.Request().Context(), account, string(recipient.OrgId), string(recipient.Recipient))
+		if err != nil {
+			utils.GetLogFromEcho(ctx).Error(err)
+			return ctx.NoContent(http.StatusInternalServerError)
+		}
+
+		results[i] = RecipientStatus{
+			RecipientWithOrg: recipient,
+			Connected:        status == connectors.ConnectionStatus_connected,
+		}
+	}
+
+	return ctx.JSON(http.StatusOK, results)
+}

--- a/internal/api/controllers/private/recipientStatus.go
+++ b/internal/api/controllers/private/recipientStatus.go
@@ -46,6 +46,11 @@ func (this *controllers) ApiInternalV2RecipientsStatus(ctx echo.Context) error {
 	for i, recipient := range input {
 		account := orgToEAN[string(recipient.OrgId)]
 
+		// take from the rate limit bucket
+		// TODO: consider moving this to the httpClient level (e.g. as an HttpRequestDoer decorator)
+		this.rateLimiter.Wait(ctx.Request().Context())
+
+		// TODO: parallelize this
 		status, err := this.cloudConnectorClient.GetConnectionStatus(ctx.Request().Context(), account, string(recipient.OrgId), string(recipient.Recipient))
 		if err != nil {
 			utils.GetLogFromEcho(ctx).Error(err)

--- a/internal/api/controllers/private/types.gen.go
+++ b/internal/api/controllers/private/types.gen.go
@@ -7,6 +7,29 @@ import (
 	externalRef0 "playbook-dispatcher/internal/api/controllers/public"
 )
 
+// OrgId defines model for OrgId.
+type OrgId string
+
+// RecipientStatus defines model for RecipientStatus.
+type RecipientStatus struct {
+	// Embedded struct due to allOf(#/components/schemas/RecipientWithOrg)
+	RecipientWithOrg `yaml:",inline"`
+	// Embedded fields due to inline allOf schema
+
+	// Indicates whether a connection is established with the recipient
+	Connected bool `json:"connected"`
+}
+
+// RecipientWithOrg defines model for RecipientWithOrg.
+type RecipientWithOrg struct {
+
+	// Identifier of the tenant
+	OrgId OrgId `json:"org_id"`
+
+	// Identifier of the host to which a given Playbook is addressed
+	Recipient externalRef0.RunRecipient `json:"recipient"`
+}
+
 // RunCreated defines model for RunCreated.
 type RunCreated struct {
 
@@ -58,5 +81,11 @@ type RunsCreated []RunCreated
 // ApiInternalRunsCreateJSONBody defines parameters for ApiInternalRunsCreate.
 type ApiInternalRunsCreateJSONBody []RunInput
 
+// ApiInternalV2RecipientsStatusJSONBody defines parameters for ApiInternalV2RecipientsStatus.
+type ApiInternalV2RecipientsStatusJSONBody []RecipientWithOrg
+
 // ApiInternalRunsCreateRequestBody defines body for ApiInternalRunsCreate for application/json ContentType.
 type ApiInternalRunsCreateJSONRequestBody ApiInternalRunsCreateJSONBody
+
+// ApiInternalV2RecipientsStatusRequestBody defines body for ApiInternalV2RecipientsStatus for application/json ContentType.
+type ApiInternalV2RecipientsStatusJSONRequestBody ApiInternalV2RecipientsStatusJSONBody

--- a/internal/api/main.go
+++ b/internal/api/main.go
@@ -88,6 +88,7 @@ func Start(
 	internal.Use(middleware.CheckPskAuth(authConfig))
 	internal.Use(oapiMiddleware.OapiRequestValidator(privateSpec))
 	internal.POST("/dispatch", privateController.ApiInternalRunsCreate)
+	internal.POST("/v2/recipients/status", privateController.ApiInternalV2RecipientsStatus)
 
 	publicController := public.CreateController(db, cloudConnectorClient)
 	public := server.Group("/api/playbook-dispatcher")

--- a/internal/api/tests/private/recipientStatus_test.go
+++ b/internal/api/tests/private/recipientStatus_test.go
@@ -1,0 +1,64 @@
+package private
+
+import (
+	"net/http"
+	"playbook-dispatcher/internal/common/utils/test"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func getStatus(payload ApiInternalV2RecipientsStatusJSONRequestBody) (*[]RecipientStatus, *ApiInternalV2RecipientsStatusResponse) {
+	resp, err := client.ApiInternalV2RecipientsStatus(test.TestContext(), payload)
+	Expect(err).ToNot(HaveOccurred())
+	res, err := ParseApiInternalV2RecipientsStatusResponse(resp)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(res.StatusCode()).To(Equal(http.StatusOK))
+
+	return res.JSON200, res
+}
+
+var _ = Describe("recipient status", func() {
+	Describe("get status happy path", func() {
+		It("single recipient", func() {
+
+			payload := ApiInternalV2RecipientsStatusJSONRequestBody{
+				RecipientWithOrg{
+					OrgId:     "5318290",
+					Recipient: "214f2dc3-eda5-4230-9800-579b020be25b",
+				},
+			}
+
+			result, _ := getStatus(payload)
+
+			Expect(*result).To(HaveLen(1))
+			Expect((*result)[0].OrgId).To(Equal(payload[0].OrgId))
+			Expect((*result)[0].Recipient).To(Equal(payload[0].Recipient))
+			Expect((*result)[0].Connected).To(BeTrue())
+		})
+
+		It("multiple recipients", func() {
+
+			payload := ApiInternalV2RecipientsStatusJSONRequestBody{
+				RecipientWithOrg{
+					OrgId:     "5318290",
+					Recipient: "214f2dc3-eda5-4230-9800-579b020be25b",
+				},
+				RecipientWithOrg{
+					OrgId:     "5318290",
+					Recipient: "411cb203-f8c9-480e-ba20-1efbc74e3a33",
+				},
+			}
+
+			result, _ := getStatus(payload)
+
+			Expect(*result).To(HaveLen(2))
+			Expect((*result)[0].OrgId).To(Equal(payload[0].OrgId))
+			Expect((*result)[0].Recipient).To(Equal(payload[0].Recipient))
+			Expect((*result)[0].Connected).To(BeTrue())
+			Expect((*result)[1].OrgId).To(Equal(payload[1].OrgId))
+			Expect((*result)[1].Recipient).To(Equal(payload[1].Recipient))
+			Expect((*result)[1].Connected).To(BeFalse())
+		})
+	})
+})

--- a/internal/api/tests/public/client.gen.go
+++ b/internal/api/tests/public/client.gen.go
@@ -148,10 +148,11 @@ type RunStatus string
 
 // List of RunStatus
 const (
-	RunStatus_failure RunStatus = "failure"
-	RunStatus_running RunStatus = "running"
-	RunStatus_success RunStatus = "success"
-	RunStatus_timeout RunStatus = "timeout"
+	RunStatus_canceled RunStatus = "canceled"
+	RunStatus_failure  RunStatus = "failure"
+	RunStatus_running  RunStatus = "running"
+	RunStatus_success  RunStatus = "success"
+	RunStatus_timeout  RunStatus = "timeout"
 )
 
 // RunTimeout defines model for RunTimeout.
@@ -177,10 +178,11 @@ type StatusNullable string
 
 // List of StatusNullable
 const (
-	StatusNullable_failure StatusNullable = "failure"
-	StatusNullable_running StatusNullable = "running"
-	StatusNullable_success StatusNullable = "success"
-	StatusNullable_timeout StatusNullable = "timeout"
+	StatusNullable_canceled StatusNullable = "canceled"
+	StatusNullable_failure  StatusNullable = "failure"
+	StatusNullable_running  StatusNullable = "running"
+	StatusNullable_success  StatusNullable = "success"
+	StatusNullable_timeout  StatusNullable = "timeout"
 )
 
 // UpdatedAt defines model for UpdatedAt.

--- a/internal/common/constants/constants.go
+++ b/internal/common/constants/constants.go
@@ -9,4 +9,5 @@ const (
 	HeaderCloudConnectorClientID = "x-rh-cloud-connector-client-id"
 	HeaderCloudConnectorAccount  = "x-rh-cloud-connector-account"
 	HeaderCloudConnectorPSK      = "x-rh-cloud-connector-psk"
+	HeaderCloudConnectorOrgID    = "x-rh-cloud-connector-org-id"
 )

--- a/schema/private.openapi.yaml
+++ b/schema/private.openapi.yaml
@@ -37,6 +37,7 @@ paths:
   /internal/v2/recipients/status:
     post:
       summary: Obtain connection status of recipient(s)
+      description: Indicates whether the given recipient(s) are available
       operationId: api.internal.v2.recipients.status
       requestBody:
         content:
@@ -141,7 +142,7 @@ components:
         - connected
 
     OrgId:
-      description: Identifier of the tenant
+      description: Identifies the organization that the given resource belongs to
       type: string
       minLength: 1
       maxLength: 10

--- a/schema/private.openapi.yaml
+++ b/schema/private.openapi.yaml
@@ -34,6 +34,28 @@ paths:
               schema:
                 $ref: '#/components/schemas/RunsCreated'
 
+  /internal/v2/recipients/status:
+    post:
+      summary: Obtain connection status of recipient(s)
+      operationId: api.internal.v2.recipients.status
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/RecipientWithOrg'
+              minItems: 1
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RecipientStatus'
+
 components:
   schemas:
     RunInput:
@@ -95,3 +117,31 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/RunCreated'
+
+    RecipientWithOrg:
+      type: object
+      properties:
+        recipient:
+          $ref: './public.openapi.yaml#/components/schemas/RunRecipient'
+        org_id:
+          $ref: '#/components/schemas/OrgId'
+      required:
+      - recipient
+      - org_id
+
+    RecipientStatus:
+      allOf:
+      - $ref: '#/components/schemas/RecipientWithOrg'
+      - type: object
+        properties:
+          connected:
+            type: boolean
+            description: Indicates whether a connection is established with the recipient
+        required:
+        - connected
+
+    OrgId:
+      description: Identifier of the tenant
+      type: string
+      minLength: 1
+      maxLength: 10


### PR DESCRIPTION
## What?
Adding a new API operation for determining connection status of a recipient.

## Why?
It will allow PD consumers to check the connection status before attempting to run a playbook. Can be used e.g. for Remediations' pre-flight check

## How?
This is implemented by making a call to Cloud Connector's connection status resource.

## Testing
Tests added

## Anything Else?
This is not a complete implementation because:

- the org_id to EAN translator is not implemented - waiting for https://issues.redhat.com/browse/RHCLOUD-17654
- the connection status operation we're calling is not the correct one - waiting for https://github.com/RedHatInsights/cloud-connector/pull/108

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
