### PR TITLE
define TenantIDTranslator interface + mock implementation

### DIFF
--- a/internal/api/connectors/tenants/translator.mock.go
+++ b/internal/api/connectors/tenants/translator.mock.go
@@ -1,0 +1,61 @@
+package tenants
+
+import (
+	"context"
+	"fmt"
+	"playbook-dispatcher/internal/common/utils"
+)
+
+type mockTenantIDTranslator struct {
+	orgIDToEAN map[string]*string
+	eanToOrgID map[string]string
+}
+
+func NewMockTenantIDTranslator() TenantIDTranslator {
+	orgIDToEAN := map[string]*string{
+		"5318290":  utils.StringRef("901578"),
+		"12900172": utils.StringRef("6377882"),
+		"14656001": utils.StringRef("7135271"),
+		"11789772": utils.StringRef("6089719"),
+	}
+
+	return &mockTenantIDTranslator{
+		orgIDToEAN: orgIDToEAN,
+		eanToOrgID: inverseMap(orgIDToEAN),
+	}
+}
+
+func (this *mockTenantIDTranslator) EANToOrgID(ctx context.Context, ean string) (orgId string, err error) {
+	value, ok := this.eanToOrgID[ean]
+
+	if !ok {
+		return "", unsupportedError()
+	}
+
+	return value, nil
+}
+
+func (this *mockTenantIDTranslator) OrgIDToEAN(ctx context.Context, orgId string) (ean *string, err error) {
+	value, ok := this.orgIDToEAN[orgId]
+
+	if !ok {
+		return nil, unsupportedError()
+	}
+
+	return value, nil
+}
+
+func inverseMap(input map[string]*string) (result map[string]string) {
+	result = make(map[string]string, len(input))
+	for key, value := range input {
+		if value != nil {
+			result[*value] = key
+		}
+	}
+
+	return
+}
+
+func unsupportedError() error {
+	return fmt.Errorf("Unsupported operation (mock implementation)")
+}

--- a/internal/api/connectors/tenants/types.go
+++ b/internal/api/connectors/tenants/types.go
@@ -1,0 +1,16 @@
+package tenants
+
+import (
+	"context"
+)
+
+// This service handles translation between tenant identifiers.
+// Namely, it converts an org_id to EAN (EBS account number) and vice versa.
+type TenantIDTranslator interface {
+
+	// Converts an EAN (EBS account number) to org_id
+	EANToOrgID(ctx context.Context, ean string) (orgId string, err error)
+
+	// Converts an org_id to EAN (EBS account number). May return nil if the org_id belongs to an anemic tenant
+	OrgIDToEAN(ctx context.Context, orgId string) (ean *string, err error)
+}


### PR DESCRIPTION
## What?
This PR defines an interface and mock implementation of a component for translating between the two tenant identifiers.

## Why?
PD will need the ability to translate between the two tenant identifiers. Even though the implementation is not available at this point, I am adding the interface now so that different initiatives in flight (RHC/Sat, the org_id migration itself) can be coded against it now.

## How?
Mock implementation with a small hard-coded mapping.

## Testing
No tests added for the mock implementation.

## Anything Else?
https://docs.google.com/document/u/1/d/1KDkGN5guEbZzpn8quSlhJLaM8JhMtmfSrsX0LO05tCs/edit

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
