### PR TITLE
log identity header in internal API calls

### DIFF
--- a/internal/api/middleware/pskAuth.go
+++ b/internal/api/middleware/pskAuth.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/labstack/echo/v4"
+	"go.uber.org/zap"
 )
 
 type principalKey int
@@ -21,6 +22,8 @@ var envMatcher = regexp.MustCompile(`^PSK_AUTH_(.+?)=(.+?)$`)
 func CheckPskAuth(authKeys map[string]string) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
+			checkIdentityHeader(c.Request(), utils.GetLogFromEcho(c))
+
 			authorization := c.Request().Header.Get("authorization")
 
 			if authorization == "" {
@@ -69,4 +72,11 @@ func BuildPskAuthConfigFromEnv() map[string]string {
 	}
 
 	return result
+}
+
+// TODO: enable x509 for auth in the future
+func checkIdentityHeader(request *http.Request, log *zap.SugaredLogger) {
+	if identity := request.Header.Get("x-rh-identity"); identity != "" {
+		log.Debugw("received identity header", "identity", identity)
+	}
 }

--- a/internal/api/middleware/pskAuth_test.go
+++ b/internal/api/middleware/pskAuth_test.go
@@ -1,14 +1,17 @@
 package middleware
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"playbook-dispatcher/internal/common/utils"
 
 	"github.com/labstack/echo/v4"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
 )
 
 const key = "secret"
@@ -32,6 +35,7 @@ func testPskAuth(req *http.Request) (*httptest.ResponseRecorder, error) {
 func newReqInternal() *http.Request {
 	req, err := http.NewRequest("GET", "/internal/dispatch", nil)
 	Expect(err).ToNot(HaveOccurred())
+	req = req.WithContext(utils.SetLog(context.Background(), zap.NewNop().Sugar()))
 	return req
 }
 


### PR DESCRIPTION
## What?
Log identity header in internal API calls

## Why?
Minimal prework for future support of x509 cert authentication in PD internal API

## How?
Using the logger from request context

## Testing
Manual

## Anything Else?


## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
