### PR TITLE
fix db adapter for gorm - explicitly associate context

### DIFF
--- a/internal/api/controllers/public/runHostsList.go
+++ b/internal/api/controllers/public/runHostsList.go
@@ -6,7 +6,6 @@ import (
 	"playbook-dispatcher/internal/api/instrumentation"
 	"playbook-dispatcher/internal/api/middleware"
 	"playbook-dispatcher/internal/api/rbac"
-	"playbook-dispatcher/internal/common/db"
 	dbModel "playbook-dispatcher/internal/common/model/db"
 	"playbook-dispatcher/internal/common/utils"
 
@@ -16,9 +15,6 @@ import (
 )
 
 func (this *controllers) ApiRunHostsList(ctx echo.Context, params ApiRunHostsListParams) error {
-	db.SetLog(this.database, utils.GetLogFromEcho(ctx))
-	defer db.ClearLog(this.database)
-
 	identity := identityMiddleware.Get(ctx.Request().Context())
 
 	limit := getLimit(params.Limit)
@@ -30,6 +26,7 @@ func (this *controllers) ApiRunHostsList(ctx echo.Context, params ApiRunHostsLis
 	}
 
 	queryBuilder := this.database.
+		WithContext(ctx.Request().Context()).
 		Table("run_hosts").
 		Joins("INNER JOIN runs on runs.id = run_hosts.run_id").
 		Where("runs.account = ?", identity.Identity.AccountNumber)

--- a/internal/api/controllers/public/runsList.go
+++ b/internal/api/controllers/public/runsList.go
@@ -6,7 +6,6 @@ import (
 	"playbook-dispatcher/internal/api/instrumentation"
 	"playbook-dispatcher/internal/api/middleware"
 	"playbook-dispatcher/internal/api/rbac"
-	"playbook-dispatcher/internal/common/db"
 	dbModel "playbook-dispatcher/internal/common/model/db"
 	"playbook-dispatcher/internal/common/utils"
 	"strings"
@@ -39,13 +38,11 @@ func mapFieldsToSql(field string) string {
 func (this *controllers) ApiRunsList(ctx echo.Context, params ApiRunsListParams) error {
 	var dbRuns []dbModel.Run
 
-	db.SetLog(this.database, utils.GetLogFromEcho(ctx))
-	defer db.ClearLog(this.database)
-
 	identity := identityMiddleware.Get(ctx.Request().Context())
+	db := this.database.WithContext(ctx.Request().Context())
 
 	// tenant isolation
-	queryBuilder := this.database.Table("runs").Where("account = ?", identity.Identity.AccountNumber)
+	queryBuilder := db.Table("runs").Where("account = ?", identity.Identity.AccountNumber)
 
 	// rbac
 	permissions := middleware.GetPermissions(ctx)

--- a/internal/api/dispatch/impl.go
+++ b/internal/api/dispatch/impl.go
@@ -5,7 +5,6 @@ import (
 	"playbook-dispatcher/internal/api/connectors"
 	"playbook-dispatcher/internal/api/dispatch/protocols"
 	"playbook-dispatcher/internal/api/instrumentation"
-	"playbook-dispatcher/internal/common/db"
 	"playbook-dispatcher/internal/common/model/generic"
 	"playbook-dispatcher/internal/common/utils"
 
@@ -51,9 +50,6 @@ func getProtocol(runInput generic.RunInput) protocols.Protocol {
 func (this *dispatchManager) ProcessRun(ctx context.Context, account string, service string, run generic.RunInput) (runID, correlationID uuid.UUID, err error) {
 	correlationID = this.newCorrelationId()
 	ctx = utils.WithCorrelationId(ctx, correlationID.String())
-
-	db.SetLog(this.db, utils.GetLogFromContext(ctx))
-	defer db.ClearLog(this.db)
 
 	this.applyDefaults(&run)
 

--- a/internal/common/utils/logging.go
+++ b/internal/common/utils/logging.go
@@ -95,12 +95,24 @@ func SetLog(ctx context.Context, log *zap.SugaredLogger) context.Context {
 	return context.WithValue(ctx, loggerKey, log)
 }
 
-func GetLogFromContext(ctx context.Context) *zap.SugaredLogger {
-	if log, ok := ctx.Value(loggerKey).(*zap.SugaredLogger); !ok {
-		panic("Logger missing in context")
-	} else {
+func GetLogFromContextIfAvailable(ctx context.Context) *zap.SugaredLogger {
+	if value := ctx.Value(loggerKey); value == nil {
+		return nil
+	} else if log, ok := value.(*zap.SugaredLogger); ok {
 		return log
+	} else {
+		panic("Unexpected logger type in context")
 	}
+}
+
+func GetLogFromContext(ctx context.Context) *zap.SugaredLogger {
+	log := GetLogFromContextIfAvailable(ctx)
+
+	if log == nil {
+		panic("Logger missing in context")
+	}
+
+	return log
 }
 
 func GetLogFromEcho(ctx echo.Context) *zap.SugaredLogger {

--- a/internal/response-consumer/handler.go
+++ b/internal/response-consumer/handler.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"playbook-dispatcher/internal/common/ansible"
 	"playbook-dispatcher/internal/common/constants"
-	database "playbook-dispatcher/internal/common/db"
 	kafkaUtils "playbook-dispatcher/internal/common/kafka"
 	"playbook-dispatcher/internal/common/model/db"
 	"playbook-dispatcher/internal/common/model/message"
@@ -75,12 +74,9 @@ func (this *handler) onMessage(ctx context.Context, msg *k.Message) {
 
 	var runsUpdated int64
 
-	database.SetLog(this.db, utils.GetLogFromContext(ctx))
-	defer database.ClearLog(this.db)
-
 	run := db.Run{}
 
-	err = this.db.Transaction(func(tx *gorm.DB) error {
+	err = this.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		baseQuery := tx.Model(db.Run{}).
 			Where("account = ?", value.Account).
 			Where("correlation_id = ?", correlationId)


### PR DESCRIPTION
## What?
Replace broken log adapter for gorm with context passing.

## Why?
I don't know what I was thinking but the old implementation was plain wrong and would not work properly with concurrent requests.

## How?
Use the logger from request context. Pass the context explicitly to gorm.

## Testing
Manually tested

## Anything Else?


## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
