### PR TITLE
switch to "foreman_rh_cloud" as the directive for Satellite

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,13 +216,13 @@ For each Playbook run request a message with the following format is sent to Clo
 
 See [rhc-worker-playbook](https://github.com/RedHatInsights/rhc-worker-playbook) for details.
 
-### rhc-cloud-connector-worker
+### foreman_rh_cloud
 
 For each Playbook run request a message with the following format is sent to Cloud Connector:
 
 ```javascript
     "account":"540155",
-    "directive":"rhc-cloud-connector-worker",
+    "directive":"foreman_rh_cloud",
     "recipient":"869fe355-4b69-43f6-82ff-d151dddee472", // id of the cloud connector client
     "metadata":{
         "operation": "run",
@@ -251,7 +251,7 @@ For each Playbook run request a message with the following format is sent to Clo
     "payload": "https://cloud.redhat.com/api/v1/remediations/1234/playbook"
 ```
 
-See [rhc-cloud-connector-worker](https://github.com/ShimShtein/rhc-cloud-connector-worker) for details.
+See [foreman_rh_cloud](https://github.com/ShimShtein/foreman_rh_cloud) for details.
 
 ## Development
 

--- a/internal/api/dispatch/protocols/definitions.go
+++ b/internal/api/dispatch/protocols/definitions.go
@@ -2,7 +2,7 @@ package protocols
 
 const (
 	RunnerDirective    Directive = "rhc-worker-playbook"
-	SatelliteDirective Directive = "rhc-cloud-connector-worker"
+	SatelliteDirective Directive = "foreman_rh_cloud"
 	LabelRunnerRequest           = "ansible"
 	LabelSatRequest              = "satellite"
 )

--- a/internal/api/dispatch/protocols/satellite_test.go
+++ b/internal/api/dispatch/protocols/satellite_test.go
@@ -12,7 +12,7 @@ import (
 
 var _ = Describe("Satellite Protocol", func() {
 	It("uses the correct directive", func() {
-		Expect(string(SatelliteProtocol.GetDirective())).To(Equal("rhc-cloud-connector-worker"))
+		Expect(string(SatelliteProtocol.GetDirective())).To(Equal("foreman_rh_cloud"))
 	})
 
 	Describe("metadata", func() {


### PR DESCRIPTION
## What?
Changing the directive used in signals sent to Satellite

## Why?
Requested by the Satellite team

## How?
find/replace

## Testing
Tests are updated

## Anything Else?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
