### PR TITLE
OrgID L2 Support

### DIFF
--- a/event-streams/src/main/java/com/redhat/cloud/platform/playbook_dispatcher/RunEventTransform.java
+++ b/event-streams/src/main/java/com/redhat/cloud/platform/playbook_dispatcher/RunEventTransform.java
@@ -34,6 +34,7 @@ public class RunEventTransform<T extends ConnectRecord<T>> implements Transforma
     static final String HEADER_SERVICE = "service";
     static final String HEADER_STATUS = "status";
     static final String HEADER_ACCOUNT = "account";
+    static final String HEADER_ORGID = "org_id";
 
     private static final String CONFIG_TOPIC = "topic";
     private static final String CONFIG_TABLE = "table";
@@ -105,7 +106,8 @@ public class RunEventTransform<T extends ConnectRecord<T>> implements Transforma
             .addString(HEADER_EVENT_TYPE, event.getEventType().value())
             .addString(HEADER_SERVICE, event.getPayload().getService())
             .addString(HEADER_STATUS, event.getPayload().getStatus().value())
-            .addString(HEADER_ACCOUNT, event.getPayload().getAccount());
+            .addString(HEADER_ACCOUNT, event.getPayload().getAccount())
+            .addString(HEADER_ORGID, event.getPayload().getOrgId());
     }
 
     private String transformKey(Struct key) {
@@ -135,6 +137,7 @@ public class RunEventTransform<T extends ConnectRecord<T>> implements Transforma
         final Payload payload = new Payload();
         payload.setId(input.getString("id"));
         payload.setAccount(input.getString("account"));
+        payload.setOrgId(input.getString("org_id"));
         payload.setRecipient(input.getString("recipient"));
         payload.setCorrelationId(input.getString("correlation_id"));
         payload.setService(input.getString("service"));

--- a/event-streams/src/main/java/com/redhat/cloud/platform/playbook_dispatcher/RunEventTransform.java
+++ b/event-streams/src/main/java/com/redhat/cloud/platform/playbook_dispatcher/RunEventTransform.java
@@ -137,7 +137,6 @@ public class RunEventTransform<T extends ConnectRecord<T>> implements Transforma
         final Payload payload = new Payload();
         payload.setId(input.getString("id"));
         payload.setAccount(input.getString("account"));
-        payload.setOrgId(input.getString("org_id"));
         payload.setRecipient(input.getString("recipient"));
         payload.setCorrelationId(input.getString("correlation_id"));
         payload.setService(input.getString("service"));
@@ -146,6 +145,10 @@ public class RunEventTransform<T extends ConnectRecord<T>> implements Transforma
         payload.setTimeout(input.getInt32("timeout"));
         payload.setCreatedAt(input.getString("created_at"));
         payload.setUpdatedAt(input.getString("updated_at"));
+        
+        if (input.get("org_id") != null) {
+            payload.setOrgId(input.getString("org_id"));
+        }
 
         if (input.get("playbook_name") != null) {
             payload.setName(input.getString("playbook_name"));

--- a/event-streams/src/main/java/com/redhat/cloud/platform/playbook_dispatcher/types/Payload.java
+++ b/event-streams/src/main/java/com/redhat/cloud/platform/playbook_dispatcher/types/Payload.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 @JsonPropertyOrder({
     "id",
     "account",
+    "org_id",
     "recipient",
     "correlation_id",
     "service",
@@ -46,6 +47,8 @@ public class Payload {
      */
     @JsonProperty("account")
     private String account;
+    @JsonProperty("org_id")
+    private String orgId;
     /**
      * 
      * (Required)
@@ -156,6 +159,16 @@ public class Payload {
     @JsonProperty("account")
     public void setAccount(String account) {
         this.account = account;
+    }
+
+    @JsonProperty("org_id")
+    public String getOrgId() {
+        return orgId;
+    }
+
+    @JsonProperty("org_id")
+    public void setOrgId(String orgId) {
+        this.orgId = orgId;
     }
 
     /**
@@ -390,6 +403,10 @@ public class Payload {
         sb.append('=');
         sb.append(((this.account == null)?"<null>":this.account));
         sb.append(',');
+        sb.append("orgId");
+        sb.append('=');
+        sb.append(((this.orgId == null)?"<null>":this.orgId));
+        sb.append(',');
         sb.append("recipient");
         sb.append('=');
         sb.append(((this.recipient == null)?"<null>":this.recipient));
@@ -454,6 +471,7 @@ public class Payload {
     public int hashCode() {
         int result = 1;
         result = ((result* 31)+((this.webConsoleUrl == null)? 0 :this.webConsoleUrl.hashCode()));
+        result = ((result* 31)+((this.orgId == null)? 0 :this.orgId.hashCode()));
         result = ((result* 31)+((this.url == null)? 0 :this.url.hashCode()));
         result = ((result* 31)+((this.timeout == null)? 0 :this.timeout.hashCode()));
         result = ((result* 31)+((this.labels == null)? 0 :this.labels.hashCode()));
@@ -480,7 +498,7 @@ public class Payload {
             return false;
         }
         Payload rhs = ((Payload) other);
-        return ((((((((((((((((this.webConsoleUrl == rhs.webConsoleUrl)||((this.webConsoleUrl!= null)&&this.webConsoleUrl.equals(rhs.webConsoleUrl)))&&((this.url == rhs.url)||((this.url!= null)&&this.url.equals(rhs.url))))&&((this.timeout == rhs.timeout)||((this.timeout!= null)&&this.timeout.equals(rhs.timeout))))&&((this.labels == rhs.labels)||((this.labels!= null)&&this.labels.equals(rhs.labels))))&&((this.createdAt == rhs.createdAt)||((this.createdAt!= null)&&this.createdAt.equals(rhs.createdAt))))&&((this.service == rhs.service)||((this.service!= null)&&this.service.equals(rhs.service))))&&((this.recipient == rhs.recipient)||((this.recipient!= null)&&this.recipient.equals(rhs.recipient))))&&((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name))))&&((this.correlationId == rhs.correlationId)||((this.correlationId!= null)&&this.correlationId.equals(rhs.correlationId))))&&((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.account == rhs.account)||((this.account!= null)&&this.account.equals(rhs.account))))&&((this.recipientConfig == rhs.recipientConfig)||((this.recipientConfig!= null)&&this.recipientConfig.equals(rhs.recipientConfig))))&&((this.status == rhs.status)||((this.status!= null)&&this.status.equals(rhs.status))))&&((this.updatedAt == rhs.updatedAt)||((this.updatedAt!= null)&&this.updatedAt.equals(rhs.updatedAt))));
+        return (((((((((((((((((this.webConsoleUrl == rhs.webConsoleUrl)||((this.webConsoleUrl!= null)&&this.webConsoleUrl.equals(rhs.webConsoleUrl)))&&((this.orgId == rhs.orgId)||((this.orgId!= null)&&this.orgId.equals(rhs.orgId))))&&((this.url == rhs.url)||((this.url!= null)&&this.url.equals(rhs.url))))&&((this.timeout == rhs.timeout)||((this.timeout!= null)&&this.timeout.equals(rhs.timeout))))&&((this.labels == rhs.labels)||((this.labels!= null)&&this.labels.equals(rhs.labels))))&&((this.createdAt == rhs.createdAt)||((this.createdAt!= null)&&this.createdAt.equals(rhs.createdAt))))&&((this.service == rhs.service)||((this.service!= null)&&this.service.equals(rhs.service))))&&((this.recipient == rhs.recipient)||((this.recipient!= null)&&this.recipient.equals(rhs.recipient))))&&((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name))))&&((this.correlationId == rhs.correlationId)||((this.correlationId!= null)&&this.correlationId.equals(rhs.correlationId))))&&((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.account == rhs.account)||((this.account!= null)&&this.account.equals(rhs.account))))&&((this.recipientConfig == rhs.recipientConfig)||((this.recipientConfig!= null)&&this.recipientConfig.equals(rhs.recipientConfig))))&&((this.status == rhs.status)||((this.status!= null)&&this.status.equals(rhs.status))))&&((this.updatedAt == rhs.updatedAt)||((this.updatedAt!= null)&&this.updatedAt.equals(rhs.updatedAt))));
     }
 
     public enum Status {

--- a/event-streams/src/test/java/com/redhat/cloud/platform/playbook_dispatcher/Factory.java
+++ b/event-streams/src/test/java/com/redhat/cloud/platform/playbook_dispatcher/Factory.java
@@ -15,6 +15,7 @@ class Factory {
         return new StructBuilder()
         .put("id", "b5c80cd3-8849-46a2-97e2-368cf62a1cda")
         .put("account", "0000001")
+        .put("org_id", "5318290")
         .put("recipient", "dd018b96-da04-4651-84d1-187fa5c23f6c")
         .put("correlation_id", "97b04495-68f0-4a41-93b9-d239c0a59b4f")
         .put("url", "http://example.com")

--- a/event-streams/src/test/java/com/redhat/cloud/platform/playbook_dispatcher/RunEventTransformParameterizedTest.java
+++ b/event-streams/src/test/java/com/redhat/cloud/platform/playbook_dispatcher/RunEventTransformParameterizedTest.java
@@ -76,6 +76,7 @@ public class RunEventTransformParameterizedTest {
         assertEquals(result.headers().lastWithName(RunEventTransform.HEADER_ACCOUNT).value(), "0000001");
         assertEquals(result.headers().lastWithName(RunEventTransform.HEADER_SERVICE).value(), "test");
         assertEquals(result.headers().lastWithName(RunEventTransform.HEADER_STATUS).value(), "success");
+        assertEquals(result.headers().lastWithName(RunEventTransform.HEADER_ORGID).value(), "5318290");
     }
 
     @Test
@@ -87,6 +88,7 @@ public class RunEventTransformParameterizedTest {
         assertEquals(this.eventType, value.getEventType().value());
         assertEquals("b5c80cd3-8849-46a2-97e2-368cf62a1cda", value.getPayload().getId());
         assertEquals("0000001", value.getPayload().getAccount());
+        assertEquals("5318290", value.getPayload().getOrgId());
         assertEquals("dd018b96-da04-4651-84d1-187fa5c23f6c", value.getPayload().getRecipient());
         assertEquals("97b04495-68f0-4a41-93b9-d239c0a59b4f", value.getPayload().getCorrelationId());
         assertEquals("test", value.getPayload().getService());

--- a/internal/api/connectors/tenants/translator.mock.go
+++ b/internal/api/connectors/tenants/translator.mock.go
@@ -3,6 +3,7 @@ package tenants
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"playbook-dispatcher/internal/common/utils"
 )
 
@@ -11,13 +12,19 @@ type mockTenantIDTranslator struct {
 	eanToOrgID map[string]string
 }
 
-func NewMockTenantIDTranslator() TenantIDTranslator {
+func NewMockTenantIDTranslator(accountNumbers ...string) TenantIDTranslator {
 	orgIDToEAN := map[string]*string{
 		"5318290":  utils.StringRef("901578"),
 		"12900172": utils.StringRef("6377882"),
 		"14656001": utils.StringRef("7135271"),
 		"11789772": utils.StringRef("6089719"),
 		"3340851":  utils.StringRef("0369233"),
+	}
+
+	// Optionally generate orgIds for provided account numbers
+	for _, accountNumber := range accountNumbers {
+		randomOrgID := fmt.Sprintf("%07d", rand.Intn(9999999))
+		orgIDToEAN[randomOrgID] = utils.StringRef(accountNumber)
 	}
 
 	return &mockTenantIDTranslator{

--- a/internal/api/controllers/public/conversions.go
+++ b/internal/api/controllers/public/conversions.go
@@ -10,6 +10,7 @@ import (
 const (
 	fieldId            = "id"
 	fieldAccount       = "account"
+	fieldOrgId         = "org_id"
 	fieldRecipient     = "recipient"
 	fieldUrl           = "url"
 	fieldLabels        = "labels"
@@ -29,7 +30,7 @@ const (
 )
 
 var (
-	runFields     = utils.IndexStrings(fieldId, fieldAccount, fieldRecipient, fieldUrl, fieldLabels, fieldTimeout, fieldStatus, fieldCreatedAt, fieldUpdatedAt, fieldService, fieldCorrelationId, fieldName, fieldWebConsoleUrl)
+	runFields     = utils.IndexStrings(fieldId, fieldAccount, fieldOrgId, fieldRecipient, fieldUrl, fieldLabels, fieldTimeout, fieldStatus, fieldCreatedAt, fieldUpdatedAt, fieldService, fieldCorrelationId, fieldName, fieldWebConsoleUrl)
 	runHostFields = utils.IndexStrings(fieldHost, fieldRun, fieldStatus, fieldStdout, fieldLinks, fieldInventoryId)
 )
 
@@ -58,6 +59,9 @@ func dbRuntoApiRun(r *dbModel.Run, fields []string) *Run {
 		case fieldAccount:
 			value := Account(r.Account)
 			run.Account = &value
+		case fieldOrgId:
+			value := OrgId(r.OrgID)
+			run.OrgId = &value
 		case fieldRecipient:
 			run.Recipient = (*RunRecipient)(convertUuid(r.Recipient))
 		case fieldUrl:

--- a/internal/response-consumer/handler.go
+++ b/internal/response-consumer/handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"playbook-dispatcher/internal/api/connectors/tenants"
 	"playbook-dispatcher/internal/common/ansible"
 	"playbook-dispatcher/internal/common/constants"
 	kafkaUtils "playbook-dispatcher/internal/common/kafka"
@@ -79,16 +78,6 @@ func (this *handler) onMessage(ctx context.Context, msg *k.Message) {
 	run := db.Run{}
 
 	err = this.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-
-		idTranslator := tenants.NewMockTenantIDTranslator(value.Account)
-		if value.OrgId == "" {
-			orgIdFromEAN, err := idTranslator.EANToOrgID(ctx, value.Account)
-			if err != nil {
-				return err
-			}
-			value.OrgId = orgIdFromEAN
-		}
-
 		// Remove after testing
 		fmt.Printf("Account: %s -> OrgId: %s\n", value.Account, value.OrgId)
 

--- a/internal/response-consumer/handler.go
+++ b/internal/response-consumer/handler.go
@@ -3,6 +3,8 @@ package responseConsumer
 import (
 	"context"
 	"errors"
+	"fmt"
+	"playbook-dispatcher/internal/api/connectors/tenants"
 	"playbook-dispatcher/internal/common/ansible"
 	"playbook-dispatcher/internal/common/constants"
 	kafkaUtils "playbook-dispatcher/internal/common/kafka"
@@ -77,8 +79,22 @@ func (this *handler) onMessage(ctx context.Context, msg *k.Message) {
 	run := db.Run{}
 
 	err = this.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+
+		idTranslator := tenants.NewMockTenantIDTranslator(value.Account)
+		if value.OrgId == "" {
+			orgIdFromEAN, err := idTranslator.EANToOrgID(ctx, value.Account)
+			if err != nil {
+				return err
+			}
+			value.OrgId = orgIdFromEAN
+		}
+
+		// Remove after testing
+		fmt.Printf("Account: %s -> OrgId: %s\n", value.Account, value.OrgId)
+
 		baseQuery := tx.Model(db.Run{}).
 			Where("account = ?", value.Account).
+			// Where("org_id = ?", value.OrgId).
 			Where("correlation_id = ?", correlationId)
 
 		if selectResult := baseQuery.Select("id").First(&run); selectResult.Error != nil {

--- a/schema/run.event.yaml
+++ b/schema/run.event.yaml
@@ -17,6 +17,8 @@ properties:
         type: string
       account:
         type: string
+      org_id:
+        type: string
       recipient:
         type: string
       correlation_id:


### PR DESCRIPTION
## What?
Add L2 support for the transition from EBS account number to OrgID. [RHCLOUD-17862](https://issues.redhat.com/browse/RHCLOUD-17862)

## Why?
This is part of the transition from EBS account numbers to OrgID.

## How?
- [ ] use org_id column in response consumer queries
- [ ] implement tenant id translation for internal API (v1) and start storing org_id with each new run that is created
- [ ] run a job populating the org_id column where missing
- [ ] add org_id to public API responses
- [ ] change public API to use org_id in queries
- [ ] use org_id in logging
- [ ] add org_id to event stream (header and payload)

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
