### PR TITLE
Populate host column with inventory_id for satellite hosts

### DIFF
--- a/internal/api/dispatch/db.go
+++ b/internal/api/dispatch/db.go
@@ -47,6 +47,8 @@ func newHostRun(runHosts []generic.RunHostsInput, entityId uuid.UUID) []dbModel.
 
 		if inputHost.AnsibleHost != nil {
 			newHosts[i].Host = *inputHost.AnsibleHost
+		} else {
+			newHosts[i].Host = inputHost.InventoryId.String()
 		}
 	}
 


### PR DESCRIPTION
## What?
Populating the `host` column of the `run_host` table with the `inventory_id` for satellite hosts.

## Why?
The `host` column has a `unique` constraint attached to it. Instead of keeping the `host` field empty, which results in empty strings for `host` when queries through the public api, it'll be better to populate it with the `inventory_id` instead.

## How?
Populating the `host` with `inventory_id` when creating the host entry.

## Testing
Added 1 test to demonstrate the behavior.

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
