### PR TITLE
[Draft] Validation notifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PSK ?= secret
 
 init:
 	go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen
-	go get github.com/atombender/go-jsonschema/...@master
+	go get github.com/atombender/go-jsonschema/...@main
 	go install github.com/atombender/go-jsonschema/cmd/gojsonschema
 	pip install json2yaml
 	go install github.com/kulshekhar/fungen

--- a/internal/common/model/message/ingress.go
+++ b/internal/common/model/message/ingress.go
@@ -16,14 +16,14 @@ type IngressValidationRequest struct {
 	Timestamp   time.Time         `json:"timestamp"`
 }
 
-type IngressValidationResponse struct {
-	IngressValidationRequest
+type IngressValidationDetails struct {
 	Validation string `json:"validation"`
+	Reason string `json:"reason"`
+	Reporter string `json:"reporter"`
 }
 
-func NewResponse(req *IngressValidationRequest, result string) *IngressValidationResponse {
-	return &IngressValidationResponse{
-		IngressValidationRequest: *req,
-		Validation:               result,
-	}
+type IngressValidationResponse struct {
+	IngressValidationRequest
+	IngressValidationDetails
+	SystemID string `json:"system_id"`
 }


### PR DESCRIPTION
## What?
Update the validation failure message so that it includes required data to send to storage broker in order for a notification to be sent to a customer who opts-in

[RHCLOUD-18128](https://issues.redhat.com/browse/RHCLOUD-18128)

## Why?
In order to take advantage of the notifications system when a playbook fails, we need to add some data to the outgoing validation message. It only effects failures.

## How?
Add extra details to the validation message model./

## Testing
None yet

## Anything Else?
In order for this to be useful as written, we need to also collect some metadata from the client. System_id or satellite ID or some kind of data that points back to an individual system. Without that, it's just a notification that some system failed somewhere in their environment.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
