### PR TITLE
[RHCLOUD-18649] Mark playbook run as running unless updates from all hosts are received

### DIFF
--- a/internal/response-consumer/handler.go
+++ b/internal/response-consumer/handler.go
@@ -302,7 +302,7 @@ func inferSatPlaybookStatus(events *[]message.PlaybookSatRunResponseMessageYamlE
 	}
 
 	switch {
-	case failed && canceled || failed:
+	case failed:
 		return db.RunStatusFailure
 	case canceled:
 		return db.RunStatusCanceled
@@ -312,35 +312,16 @@ func inferSatPlaybookStatus(events *[]message.PlaybookSatRunResponseMessageYamlE
 }
 
 func inferSatHostStatus(events *[]message.PlaybookSatRunResponseMessageYamlEventsElem, host string) string {
-	finished := false
-	failed := false
-	canceled := false
-
 	for _, event := range *events {
 		if event.Host != nil && *event.Host != host {
 			continue
 		}
-		if event.Type == EventSatPlaybookFinished {
-			finished = true
-		}
-		if event.Status != nil && *event.Status == EventSatStatusCanceled {
-			canceled = true
-		}
-		if event.Status != nil && *event.Status == EventSatStatusFailure {
-			failed = true
+		if event.Type == EventSatPlaybookFinished && event.Status != nil {
+			return satStatusEventDbMap(*event.Status)
 		}
 	}
 
-	switch {
-	case finished && canceled:
-		return db.RunStatusCanceled
-	case finished && failed:
-		return db.RunStatusFailure
-	case finished && !failed || finished && !canceled:
-		return db.RunStatusSuccess
-	default:
-		return db.RunStatusRunning
-	}
+	return db.RunStatusRunning
 }
 
 func checkSatStatusPartial(events *[]message.PlaybookSatRunResponseMessageYamlEventsElem) string {


### PR DESCRIPTION
## What?
When response_full = true, marks playbook run as running until all hosts have finished running.

## Why?
bug fix

## How?
Introduced `inferSatPlaybookStatus` function. Which does the following:
* If a `playbook_run_completed` event is received returns the `status`
* Otherwise, checks whether a `playbook_run_finished` message was received from all involved hosts. If true, infers the playbook run status from those events, else marks the playbook run as `running`.

## Testing
* added 1 test to demonstrate the behavior

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
