### PR TITLE
L2 OrgID Migration Job

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -52,6 +52,15 @@ objects:
       partitions: 16
       topicName: platform.upload.validation
 
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdJobInvocation
+    metadata:
+      name: populate-org-id-column
+    spec:
+      appName: playbook-dispatcher
+      jobs:
+        - org-id-populator
+
     deployments:
     - name: api
       minReplicas: ${{REPLICAS_API}}
@@ -277,7 +286,7 @@ objects:
     - name: org-id-populator
       restartPolicy: OnFailure
       podSpec:
-        image: quay.io/dehort/tenant-utils:5228ba1e3680
+        image: ${POPULATOR_IMAGE}:${POPULATOR_IMAGE_TAG}
         command:
           - ./org-id-column-populator
           - -C
@@ -289,6 +298,17 @@ objects:
           - runs
           - --db-null-org-id-place-holder
           - unknown
+          - --ean-translator-addr
+          - http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
+        env:
+          - name: TENANT_TRANSLATOR_HOST
+            value: ${TENANT_TRANSLATOR_HOST}
+          - name: TENANT_TRANSLATOR_PORT
+            value: ${TENANT_TRANSLATOR_PORT}
+          - name: LOG_FORMAT
+            value: ${LOG_FORMAT}
+          - name: LOG_BATCH_FREQUENCY
+            value: '1'
         resources:
           limits:
             cpu: 300m
@@ -358,6 +378,12 @@ parameters:
   value: '8892'
 - name: TENANT_TRANSLATOR_IMPL
   value: impl
+- name: LOG_FORMAT
+  value: logstash
+- name: POPULATOR_IMAGE
+  value: quay.io/cloudservices/tenant-utils
+- name: POPULATOR_IMAGE_TAG
+  value: latest
 
 
 # Used for testing in ephemeral environments only.

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -311,7 +311,7 @@ objects:
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdJobInvocation
   metadata:
-    name: populate-org-id-column
+    name: populate-org-id-column-${POPULATOR_RUN_NUMBER}
   spec:
     appName: playbook-dispatcher
     jobs:
@@ -384,6 +384,8 @@ parameters:
   value: quay.io/cloudservices/tenant-utils
 - name: POPULATOR_IMAGE_TAG
   value: latest
+- name: POPULATOR_RUN_NUMBER
+  value: "1"
 
 
 # Used for testing in ephemeral environments only.

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -52,15 +52,6 @@ objects:
       partitions: 16
       topicName: platform.upload.validation
 
-  - apiVersion: cloud.redhat.com/v1alpha1
-    kind: ClowdJobInvocation
-    metadata:
-      name: populate-org-id-column
-    spec:
-      appName: playbook-dispatcher
-      jobs:
-        - org-id-populator
-
     deployments:
     - name: api
       minReplicas: ${{REPLICAS_API}}
@@ -316,6 +307,15 @@ objects:
           requests:
             cpu: 50m
             memory: 512Mi
+
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    name: populate-org-id-column
+  spec:
+    appName: playbook-dispatcher
+    jobs:
+      - org-id-populator
 
 parameters:
 - name: IMAGE_TAG

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -292,14 +292,10 @@ objects:
           - --ean-translator-addr
           - http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
         env:
-          - name: TENANT_TRANSLATOR_HOST
-            value: ${TENANT_TRANSLATOR_HOST}
-          - name: TENANT_TRANSLATOR_PORT
-            value: ${TENANT_TRANSLATOR_PORT}
           - name: LOG_FORMAT
-            value: ${LOG_FORMAT}
+            value: ${POPULATOR_LOG_FORMAT}
           - name: LOG_BATCH_FREQUENCY
-            value: '1'
+            value: '1s'
         resources:
           limits:
             cpu: 300m
@@ -378,8 +374,8 @@ parameters:
   value: '8892'
 - name: TENANT_TRANSLATOR_IMPL
   value: impl
-- name: LOG_FORMAT
-  value: logstash
+- name: POPULATOR_LOG_FORMAT
+  value: cloudwatch
 - name: POPULATOR_IMAGE
   value: quay.io/cloudservices/tenant-utils
 - name: POPULATOR_IMAGE_TAG

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -291,6 +291,8 @@ objects:
           - unknown
           - --ean-translator-addr
           - http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
+          - --prometheus-push-addr
+          - ${PROMETHEUS_PUSHGATEWAY}
         env:
           - name: LOG_FORMAT
             value: ${POPULATOR_LOG_FORMAT}
@@ -382,6 +384,8 @@ parameters:
   value: latest
 - name: POPULATOR_RUN_NUMBER
   value: "1"
+- name: PROMETHEUS_PUSHGATEWAY
+  value: "localhost"
 
 
 # Used for testing in ephemeral environments only.

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -287,6 +287,8 @@ objects:
           - org_id
           - -t
           - runs
+          - --db-null-org-id-place-holder
+          - unknown
         resources:
           limits:
             cpu: 300m

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -274,6 +274,27 @@ objects:
           requests:
             cpu: 100m
             memory: 64Mi
+    - name: org-id-populator
+      podSpec:
+        name: org-id-populator
+        restartPolicy: OnFailure
+        image: quay.io/dehort/tenant-utils:5228ba1e3680
+        command:
+          - ./org-id-column-populator
+          - -C
+          - -a
+          - account
+          - -o
+          - org_id
+          - -t
+          - runs
+        resources:
+          limits:
+            cpu: 300m
+            memory: 1Gi
+          requests:
+            cpu: 50m
+            memory: 512Mi
 
 parameters:
 - name: IMAGE_TAG

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -382,7 +382,7 @@ parameters:
   value: quay.io/cloudservices/tenant-utils
 - name: POPULATOR_IMAGE_TAG
   value: latest
-- name: POPULATOR_RUN_NUMBER
+- name: POPULATOR_RUN_NUMBER # in case we need to run populator again, just increment this
   value: "1"
 - name: PROMETHEUS_PUSHGATEWAY
   value: "localhost"

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -275,9 +275,8 @@ objects:
             cpu: 100m
             memory: 64Mi
     - name: org-id-populator
+      restartPolicy: OnFailure
       podSpec:
-        name: org-id-populator
-        restartPolicy: OnFailure
         image: quay.io/dehort/tenant-utils:5228ba1e3680
         command:
           - ./org-id-column-populator

--- a/deploy/run_org_id_populator.yaml
+++ b/deploy/run_org_id_populator.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: cloud.redhat.com/v1alpha1
-kind: ClowdJobInvocation
-metadata:
-  name: populate-org-id-column-01
-spec:
-  appName: playbook-dispatcher
-  jobs:
-    - org-id-populator

--- a/deploy/run_org_id_populator.yaml
+++ b/deploy/run_org_id_populator.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdJobInvocation
+metadata:
+  name: populate-org-id-column
+spec:
+  appName: playbook-dispatcher
+  jobs:
+    - org-id-populator

--- a/deploy/run_org_id_populator.yaml
+++ b/deploy/run_org_id_populator.yaml
@@ -2,7 +2,7 @@
 apiVersion: cloud.redhat.com/v1alpha1
 kind: ClowdJobInvocation
 metadata:
-  name: populate-org-id-column
+  name: populate-org-id-column-01
 spec:
   appName: playbook-dispatcher
   jobs:


### PR DESCRIPTION
## What?
[RHCLOUD-19301](https://issues.redhat.com/browse/RHCLOUD-19301)
Creates a job to translate EBS account numbers to OrgIDs as part of [RHCLOUD-17862](https://issues.redhat.com/browse/RHCLOUD-17862)

## Why?
This is part of the transition from EBS account numbers to OrgID.

## How?
- [x] run a job populating the org_id column where missing

## Testing
Translator was tested in ephemeral, but will need to be tested in STAGE.

## Anything Else?
This will be merged after https://github.com/RedHatInsights/playbook-dispatcher/pull/210 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
