### PR TITLE
[fix] makefile init param

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,10 @@ PSK ?= secret
 
 init:
 	go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen
-	go get github.com/atombender/go-jsonschema/...@master
+	go get github.com/atombender/go-jsonschema/...@main
 	go install github.com/atombender/go-jsonschema/cmd/gojsonschema
 	pip install json2yaml
+	go get github.com/kulshekhar/fungen
 	go install github.com/kulshekhar/fungen
 
 generate-api:


### PR DESCRIPTION
The go-jsonchema repo switch to main from master branch

The fungen module doesn't install if you don't already have it. Doing a
go get first

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Updated the makefile to work if you're setting up the project for the first time.

## Why?
The `init` makefile command will fail if you are setting up the project for the first time. The `fungen` module modified its main branch name.

## How?
Modified the Makefile

## Testing
Ran it locally and it did the right thing

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
