### PR TITLE
Sat rhc implementation observability

### DIFF
--- a/dashboard/grafana-dashboard-insights-playbook-dispatcher.configmap.yaml
+++ b/dashboard/grafana-dashboard-insights-playbook-dispatcher.configmap.yaml
@@ -11,19 +11,25 @@ data:
             "hide": true,
             "iconColor": "rgba(0, 211, 255, 1)",
             "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
             "type": "dashboard"
           }
         ]
       },
       "editable": true,
-      "gnetId": null,
+      "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "iteration": 1629901167114,
+      "iteration": 1652800467914,
       "links": [],
+      "liveNow": false,
       "panels": [
         {
           "collapsed": false,
-          "datasource": null,
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -40,12 +46,9 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "$datasource",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "fill": 1,
           "fillGradient": 0,
@@ -74,7 +77,7 @@ data:
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.2.1",
+          "pluginVersion": "8.4.1",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -84,7 +87,12 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "1 - (sum(increase(echo_http_requests_total{status=\"5xx\", service=\"playbook-dispatcher-api\"}[$__range:1m])) / sum(increase(echo_http_requests_total{service=\"playbook-dispatcher-api\"}[$__range:1m])))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "exemplar": true,
+              "expr": "(sum(increase(echo_http_requests_total{status=\"5xx\", service=\"playbook-dispatcher-api\"}[$__range:1m])) / sum(increase(echo_http_requests_total{service=\"playbook-dispatcher-api\"}[$__range:1m])))",
               "interval": "",
               "legendFormat": "Ratio of successful requests",
               "refId": "A"
@@ -101,9 +109,7 @@ data:
               "yaxis": "left"
             }
           ],
-          "timeFrom": null,
           "timeRegions": [],
-          "timeShift": null,
           "title": "Availability SLO",
           "tooltip": {
             "shared": true,
@@ -112,9 +118,7 @@ data:
           },
           "type": "graph",
           "xaxis": {
-            "buckets": null,
             "mode": "time",
-            "name": null,
             "show": true,
             "values": []
           },
@@ -123,7 +127,6 @@ data:
               "$$hashKey": "object:338",
               "decimals": 2,
               "format": "percentunit",
-              "label": null,
               "logBase": 1,
               "max": "1",
               "min": "0.9",
@@ -132,16 +135,12 @@ data:
             {
               "$$hashKey": "object:339",
               "format": "short",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             }
           ],
           "yaxis": {
-            "align": false,
-            "alignLevel": null
+            "align": false
           }
         },
         {
@@ -149,10 +148,11 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "$datasource",
+          "datasource": {
+            "uid": "$datasource"
+          },
           "fieldConfig": {
             "defaults": {
-              "custom": {},
               "links": []
             },
             "overrides": []
@@ -186,7 +186,7 @@ data:
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.2.1",
+          "pluginVersion": "8.4.1",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -215,9 +215,7 @@ data:
               "yaxis": "left"
             }
           ],
-          "timeFrom": null,
           "timeRegions": [],
-          "timeShift": null,
           "title": "Consumer lag",
           "tooltip": {
             "shared": true,
@@ -226,9 +224,7 @@ data:
           },
           "type": "graph",
           "xaxis": {
-            "buckets": null,
             "mode": "time",
-            "name": null,
             "show": true,
             "values": []
           },
@@ -245,23 +241,16 @@ data:
             {
               "$$hashKey": "object:1221",
               "format": "short",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             }
           ],
           "yaxis": {
-            "align": false,
-            "alignLevel": null
+            "align": false
           }
         },
         {
-          "cards": {
-            "cardPadding": null,
-            "cardRound": null
-          },
+          "cards": {},
           "color": {
             "cardColor": "#b4ff00",
             "colorScale": "sqrt",
@@ -271,12 +260,8 @@ data:
             "mode": "spectrum"
           },
           "dataFormat": "tsbuckets",
-          "datasource": "$datasource",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
+          "datasource": {
+            "uid": "$datasource"
           },
           "gridPos": {
             "h": 9,
@@ -302,8 +287,6 @@ data:
               "refId": "A"
             }
           ],
-          "timeFrom": null,
-          "timeShift": null,
           "title": "Latency",
           "tooltip": {
             "show": true,
@@ -313,24 +296,15 @@ data:
           "xAxis": {
             "show": true
           },
-          "xBucketNumber": null,
-          "xBucketSize": null,
           "yAxis": {
-            "decimals": null,
             "format": "none",
             "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true,
-            "splitFactor": null
+            "show": true
           },
-          "yBucketBound": "auto",
-          "yBucketNumber": null,
-          "yBucketSize": null
+          "yBucketBound": "auto"
         },
         {
           "collapsed": true,
-          "datasource": null,
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -344,11 +318,12 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "$datasource",
+              "datasource": {
+                "uid": "$datasource"
+              },
               "description": "",
               "fieldConfig": {
                 "defaults": {
-                  "custom": {},
                   "links": []
                 },
                 "overrides": []
@@ -381,7 +356,7 @@ data:
                 "alertThreshold": true
               },
               "percentage": false,
-              "pluginVersion": "7.2.1",
+              "pluginVersion": "8.4.1",
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
@@ -398,9 +373,7 @@ data:
                 }
               ],
               "thresholds": [],
-              "timeFrom": null,
               "timeRegions": [],
-              "timeShift": null,
               "title": "Request rate",
               "tooltip": {
                 "shared": true,
@@ -409,36 +382,27 @@ data:
               },
               "type": "graph",
               "xaxis": {
-                "buckets": null,
                 "mode": "time",
-                "name": null,
                 "show": true,
                 "values": []
               },
               "yaxes": [
                 {
                   "$$hashKey": "object:287",
-                  "decimals": null,
                   "format": "short",
-                  "label": null,
                   "logBase": 1,
-                  "max": null,
                   "min": "0",
                   "show": true
                 },
                 {
                   "$$hashKey": "object:288",
                   "format": "short",
-                  "label": null,
                   "logBase": 1,
-                  "max": null,
-                  "min": null,
                   "show": false
                 }
               ],
               "yaxis": {
-                "align": false,
-                "alignLevel": null
+                "align": false
               }
             },
             {
@@ -446,11 +410,13 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "$datasource",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
               "description": "",
               "fieldConfig": {
                 "defaults": {
-                  "custom": {},
                   "links": []
                 },
                 "overrides": []
@@ -483,7 +449,7 @@ data:
                 "alertThreshold": true
               },
               "percentage": false,
-              "pluginVersion": "7.2.1",
+              "pluginVersion": "8.4.1",
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
@@ -493,34 +459,85 @@ data:
               "steppedLine": false,
               "targets": [
                 {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "xMl_iMf7k"
+                  },
                   "expr": "sum(increase(response_consumer_error_total{service=\"playbook-dispatcher-response-consumer\"}[1m])) by (type)",
                   "interval": "",
                   "legendFormat": "consumer error: {{type}}",
                   "refId": "A"
                 },
                 {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "xMl_iMf7k"
+                  },
                   "expr": "sum(increase(response_consumer_validation_failure_total{service=\"playbook-dispatcher-response-consumer\"}[1m])) by (type)",
                   "interval": "",
                   "legendFormat": "consumer failure: {{type}}",
                   "refId": "B"
                 },
                 {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "xMl_iMf7k"
+                  },
                   "expr": "sum(increase(validator_failure_total{service=\"playbook-dispatcher-validator\"}[1m]))",
                   "interval": "",
                   "legendFormat": "validator failure",
                   "refId": "C"
                 },
                 {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "xMl_iMf7k"
+                  },
+                  "exemplar": true,
                   "expr": "sum(increase(validator_error_total{service=\"playbook-dispatcher-validator\"}[1m])) by (phase)",
                   "interval": "",
                   "legendFormat": "validator error: {{phase}}",
                   "refId": "D"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "$datasource"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(increase(api_error_total{service=\"playbook-dispatcher-api\"}[1m])) by (type)",
+                  "hide": false,
+                  "interval": "",
+                  "legendFormat": "api error: {{type}}",
+                  "refId": "G"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "$datasource"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(increase(api_error_total{service=\"playbook-dispatcher-api\"}[1m])) by (subtype, api_version)",
+                  "hide": false,
+                  "interval": "",
+                  "legendFormat": "api error: {{api_version}} {{subtype}}",
+                  "refId": "E"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "$datasource"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(increase(app_run_canceled_error_total{service=\"playbook-dispatcher-api\"}[1m]))",
+                  "hide": false,
+                  "interval": "",
+                  "legendFormat": "api error: playbook_run_cancel",
+                  "refId": "F"
                 }
               ],
               "thresholds": [],
-              "timeFrom": null,
               "timeRegions": [],
-              "timeShift": null,
               "title": "Errors",
               "tooltip": {
                 "shared": true,
@@ -529,43 +546,31 @@ data:
               },
               "type": "graph",
               "xaxis": {
-                "buckets": null,
                 "mode": "time",
-                "name": null,
                 "show": true,
                 "values": []
               },
               "yaxes": [
                 {
                   "$$hashKey": "object:368",
-                  "decimals": null,
                   "format": "short",
-                  "label": null,
                   "logBase": 1,
-                  "max": null,
                   "min": "0",
                   "show": true
                 },
                 {
                   "$$hashKey": "object:369",
                   "format": "short",
-                  "label": null,
                   "logBase": 1,
-                  "max": null,
-                  "min": null,
                   "show": false
                 }
               ],
               "yaxis": {
-                "align": false,
-                "alignLevel": null
+                "align": false
               }
             },
             {
-              "cards": {
-                "cardPadding": null,
-                "cardRound": null
-              },
+              "cards": {},
               "color": {
                 "cardColor": "#b4ff00",
                 "colorScale": "sqrt",
@@ -575,12 +580,8 @@ data:
                 "mode": "spectrum"
               },
               "dataFormat": "tsbuckets",
-              "datasource": "$datasource",
-              "fieldConfig": {
-                "defaults": {
-                  "custom": {}
-                },
-                "overrides": []
+              "datasource": {
+                "uid": "$datasource"
               },
               "gridPos": {
                 "h": 9,
@@ -606,8 +607,6 @@ data:
                   "refId": "A"
                 }
               ],
-              "timeFrom": null,
-              "timeShift": null,
               "title": "Connector latency",
               "tooltip": {
                 "show": true,
@@ -617,31 +616,25 @@ data:
               "xAxis": {
                 "show": true
               },
-              "xBucketNumber": null,
-              "xBucketSize": null,
               "yAxis": {
-                "decimals": null,
                 "format": "none",
                 "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true,
-                "splitFactor": null
+                "show": true
               },
-              "yBucketBound": "auto",
-              "yBucketNumber": null,
-              "yBucketSize": null
+              "yBucketBound": "auto"
             },
             {
               "aliasColors": {},
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "$datasource",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
               "description": "",
               "fieldConfig": {
                 "defaults": {
-                  "custom": {},
                   "links": []
                 },
                 "overrides": []
@@ -674,7 +667,7 @@ data:
                 "alertThreshold": true
               },
               "percentage": false,
-              "pluginVersion": "7.2.1",
+              "pluginVersion": "8.4.1",
               "pointradius": 5,
               "points": false,
               "renderer": "flot",
@@ -684,6 +677,11 @@ data:
               "steppedLine": false,
               "targets": [
                 {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "xMl_iMf7k"
+                  },
+                  "exemplar": true,
                   "expr": "sum(increase(client_request_duration_seconds_count{service=\"playbook-dispatcher-api\", result!~\"2.*\"}[1m])) by (component)",
                   "interval": "",
                   "legendFormat": "{{component}}",
@@ -691,9 +689,7 @@ data:
                 }
               ],
               "thresholds": [],
-              "timeFrom": null,
               "timeRegions": [],
-              "timeShift": null,
               "title": "Connector errors",
               "tooltip": {
                 "shared": true,
@@ -702,36 +698,27 @@ data:
               },
               "type": "graph",
               "xaxis": {
-                "buckets": null,
                 "mode": "time",
-                "name": null,
                 "show": true,
                 "values": []
               },
               "yaxes": [
                 {
                   "$$hashKey": "object:368",
-                  "decimals": null,
                   "format": "short",
-                  "label": null,
                   "logBase": 1,
-                  "max": null,
                   "min": "0",
                   "show": true
                 },
                 {
                   "$$hashKey": "object:369",
                   "format": "short",
-                  "label": null,
                   "logBase": 1,
-                  "max": null,
-                  "min": null,
                   "show": false
                 }
               ],
               "yaxis": {
-                "align": false,
-                "alignLevel": null
+                "align": false
               }
             },
             {
@@ -739,12 +726,9 @@ data:
               "bars": false,
               "dashLength": 10,
               "dashes": false,
-              "datasource": "app-sre-prod-01-prometheus",
-              "fieldConfig": {
-                "defaults": {
-                  "custom": {}
-                },
-                "overrides": []
+              "datasource": {
+                "type": "prometheus",
+                "uid": "ARw_iGB7k"
               },
               "fill": 1,
               "fillGradient": 0,
@@ -772,7 +756,7 @@ data:
                 "alertThreshold": true
               },
               "percentage": false,
-              "pluginVersion": "7.2.1",
+              "pluginVersion": "8.4.1",
               "pointradius": 2,
               "points": false,
               "renderer": "flot",
@@ -789,9 +773,7 @@ data:
                 }
               ],
               "thresholds": [],
-              "timeFrom": null,
               "timeRegions": [],
-              "timeShift": null,
               "title": "RDS storage usage",
               "tooltip": {
                 "shared": true,
@@ -800,9 +782,7 @@ data:
               },
               "type": "graph",
               "xaxis": {
-                "buckets": null,
                 "mode": "time",
-                "name": null,
                 "show": true,
                 "values": []
               },
@@ -810,34 +790,30 @@ data:
                 {
                   "$$hashKey": "object:98",
                   "format": "percent",
-                  "label": null,
                   "logBase": 1,
-                  "max": null,
-                  "min": null,
                   "show": true
                 },
                 {
                   "$$hashKey": "object:99",
                   "format": "short",
-                  "label": null,
                   "logBase": 1,
-                  "max": null,
-                  "min": null,
                   "show": true
                 }
               ],
               "yaxis": {
-                "align": false,
-                "alignLevel": null
+                "align": false
               }
             },
             {
-              "datasource": "$datasource",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
               "description": "",
               "fieldConfig": {
                 "defaults": {
                   "custom": {
-                    "align": null,
+                    "displayMode": "auto",
                     "filterable": false
                   },
                   "mappings": [],
@@ -878,11 +854,23 @@ data:
               },
               "id": 19,
               "options": {
+                "footer": {
+                  "fields": "",
+                  "reducer": [
+                    "sum"
+                  ],
+                  "show": false
+                },
                 "showHeader": true
               },
-              "pluginVersion": "7.2.1",
+              "pluginVersion": "8.4.1",
               "targets": [
                 {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "xMl_iMf7k"
+                  },
+                  "exemplar": false,
                   "expr": "sum(increase(api_run_created_total[$__range])) by (dispatching_service)",
                   "format": "table",
                   "instant": true,
@@ -891,8 +879,6 @@ data:
                   "refId": "A"
                 }
               ],
-              "timeFrom": null,
-              "timeShift": null,
               "title": "New playbook run increment",
               "transformations": [
                 {
@@ -910,13 +896,203 @@ data:
                 }
               ],
               "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "xMl_iMf7k"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 46
+              },
+              "id": 23,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "xMl_iMf7k"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(increase(api_rbac_error_total{service=\"playbook-dispatcher-api\"}[1m]))",
+                  "interval": "",
+                  "legendFormat": "rbac errors",
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "xMl_iMf7k"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(increase(api_rbac_rejected_total{service=\"playbook-dispatcher-api\"}[1m]))",
+                  "hide": false,
+                  "interval": "",
+                  "legendFormat": "rbac rejected",
+                  "refId": "B"
+                }
+              ],
+              "title": "RBAC Totals",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "xMl_iMf7k"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 46
+              },
+              "id": 21,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "xMl_iMf7k"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(increase(api_run_canceled_total[1m]))",
+                  "interval": "",
+                  "legendFormat": "Run Cancel Total",
+                  "refId": "A"
+                }
+              ],
+              "title": "Playbook Run Cancel Total",
+              "type": "timeseries"
             }
           ],
           "title": "Details",
           "type": "row"
         }
       ],
-      "schemaVersion": 26,
+      "schemaVersion": 35,
       "style": "dark",
       "tags": [
         "platform-health",
@@ -926,7 +1102,7 @@ data:
         "list": [
           {
             "current": {
-              "selected": true,
+              "selected": false,
               "text": "crcp01ue1-prometheus",
               "value": "crcp01ue1-prometheus"
             },
@@ -953,7 +1129,8 @@ data:
       "timezone": "",
       "title": "Playbook Dispatcher",
       "uid": "js1xeMwMz",
-      "version": 1
+      "version": 2,
+      "weekStart": ""
     }
 kind: ConfigMap
 metadata:

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/RedHatInsights/tenant-utils v1.0.0
+	github.com/atombender/go-jsonschema v0.9.1-0.20211117143334-fdc071e07e6c // indirect
 	github.com/aws/aws-sdk-go v1.36.28
 	github.com/confluentinc/confluent-kafka-go v1.5.2
 	github.com/deepmap/oapi-codegen v1.4.2
@@ -12,6 +13,7 @@ require (
 	github.com/globocom/echo-prometheus v0.1.2
 	github.com/golang-migrate/migrate/v4 v4.15.1
 	github.com/google/uuid v1.3.0
+	github.com/kulshekhar/fungen v0.0.0-20180224173454-7ed9e430524b // indirect
 	github.com/labstack/echo/v4 v4.1.17
 	github.com/mec07/cloudwatchwriter v0.2.4
 	github.com/onsi/ginkgo v1.16.4

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,8 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/atombender/go-jsonschema v0.9.1-0.20211117143334-fdc071e07e6c h1:NlypVwKwsevo3e4KP6ozYoZFG+Df1Bnk5l9wZwd23NE=
+github.com/atombender/go-jsonschema v0.9.1-0.20211117143334-fdc071e07e6c/go.mod h1:ev1S/jfIbe8uIdBSPPVWB0Pj7NuHTe+JkM2Gw+JaaD8=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.17.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.34.2/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
@@ -707,6 +709,8 @@ github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/ktrysmt/go-bitbucket v0.6.4/go.mod h1:9u0v3hsd2rqCHRIpbir1oP7F58uo5dq19sBYvuMoyQ4=
+github.com/kulshekhar/fungen v0.0.0-20180224173454-7ed9e430524b h1:yhv01T9j1k7K/DsNkukw1CMv+KjdPaMGpkn9AykaGXc=
+github.com/kulshekhar/fungen v0.0.0-20180224173454-7ed9e430524b/go.mod h1:DUEJ+lstFLzs07dkWsLsEZJtWQcTWAs/4BgfepBMkoI=
 github.com/labstack/echo/v4 v4.1.10/go.mod h1:i541M3Fj6f76NZtHSj7TXnyM8n2gaodfvfxNnFqi74g=
 github.com/labstack/echo/v4 v4.1.11/go.mod h1:i541M3Fj6f76NZtHSj7TXnyM8n2gaodfvfxNnFqi74g=
 github.com/labstack/echo/v4 v4.1.17 h1:PQIBaRplyRy3OjwILGkPg89JRtH2x5bssi59G2EL3fo=
@@ -765,6 +769,8 @@ github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceT
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
+github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
+github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -935,6 +941,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
+github.com/sanity-io/litter v1.1.0 h1:BllcKWa3VbZmOZbDCoszYLk7zCsKHz5Beossi8SUcTc=
+github.com/sanity-io/litter v1.1.0/go.mod h1:CJ0VCw2q4qKU7LaQr3n7UOSHzgEMgcGco7N/SkZQPjw=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
@@ -977,6 +985,7 @@ github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb6
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1-0.20171106142849-4c012f6dcd95/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/internal/api/controllers/private/runsCreate.go
+++ b/internal/api/controllers/private/runsCreate.go
@@ -38,7 +38,7 @@ func (this *controllers) ApiInternalRunsCreate(ctx echo.Context) error {
 
 		runInput := RunInputV1GenericMap(runInputV1, &orgIdString, recipient, hosts, this.config)
 
-		runID, _, err := this.dispatchManager.ProcessRun(context, string(runInputV1.Account), middleware.GetPSKPrincipal(context), runInput)
+		runID, _, err := this.dispatchManager.ProcessRun(context, string(runInputV1.Account), middleware.GetPSKPrincipal(context), runInput, "v1")
 
 		if err != nil {
 			return handleRunCreateError(err)

--- a/internal/api/controllers/private/runsCreateV2.go
+++ b/internal/api/controllers/private/runsCreateV2.go
@@ -62,7 +62,7 @@ func (this *controllers) ApiInternalV2RunsCreate(ctx echo.Context) error {
 
 		runInput := RunInputV2GenericMap(runInputV2, *ean, recipient, hosts, parsedSatID, this.config)
 
-		runID, _, err := this.dispatchManager.ProcessRun(context, *ean, middleware.GetPSKPrincipal(context), runInput)
+		runID, _, err := this.dispatchManager.ProcessRun(context, *ean, middleware.GetPSKPrincipal(context), runInput, "v2")
 
 		if err != nil {
 			return handleRunCreateError(err)

--- a/internal/api/dispatch/types.go
+++ b/internal/api/dispatch/types.go
@@ -10,7 +10,7 @@ import (
 
 // orchestrates sending of playbook run signal and storing the database records
 type DispatchManager interface {
-	ProcessRun(ctx context.Context, account string, service string, run generic.RunInput) (runID, correlationID uuid.UUID, err error)
+	ProcessRun(ctx context.Context, account string, service string, run generic.RunInput, api_verison string) (runID, correlationID uuid.UUID, err error)
 	ProcessCancel(ctx context.Context, account string, cancel generic.CancelInput) (runID, correlationID uuid.UUID, err error)
 }
 


### PR DESCRIPTION
## What?
Add observability for Sat RHC implementation.

## Why?
Now that the Sat RHC feature has been implemented we wanted to make some changes to our metrics and dashboards to reflect this feature.

## How?
Added error metrics to the Grafana Error table:
Playbook Run Create (V1 & V2)
Playbook Run Hosts Create (V1 & V2)
Playbook Run Read
Playbook Run Cancel

Added additional panels for RBAC Errors & Playbook Run Cancel errors.

Updated error pannels to reflect both V1 api and V2 api with newly added label.

## Testing
Tested prometheus queries in the prod prometheus instance & tested dashboard.

## Anything Else?
JIRA:  https://issues.redhat.com/browse/RHCLOUD-17941

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] General Coding Practices
- [ ] Memory Management
