### PR TITLE
Support for uuidv5 as the sat_id [RHCLOUD-19427]

### DIFF
--- a/internal/api/connectors/cloudConnector.mock.go
+++ b/internal/api/connectors/cloudConnector.mock.go
@@ -32,6 +32,11 @@ func (this *cloudConnectorClientMock) SendCloudConnectorRequest(
 	}
 
 	id := uuid.New().String()
+
+	if recipient.String() == "9200e4a3-c97c-4021-9856-82fa4673e8d2" {
+		return &id, false, nil
+	}
+
 	return &id, false, nil
 }
 

--- a/internal/api/connectors/cloudConnector.mock.go
+++ b/internal/api/connectors/cloudConnector.mock.go
@@ -31,11 +31,11 @@ func (this *cloudConnectorClientMock) SendCloudConnectorRequest(
 		return nil, false, fmt.Errorf("timeout")
 	}
 
-	id := uuid.New().String()
-
-	if recipient.String() == "9200e4a3-c97c-4021-9856-82fa4673e8d2" {
-		return &id, false, nil
+	if recipient.String() == "9200e4a3-c97c-4021-9856-82fa4673e8d2" && metadata["sat_id"] != "9274c274-a258-5d00-91fe-dbe0f7849cef" {
+		return nil, false, fmt.Errorf("sat_id mismatch")
 	}
+
+	id := uuid.New().String()
 
 	return &id, false, nil
 }

--- a/internal/api/main.go
+++ b/internal/api/main.go
@@ -32,7 +32,8 @@ const specFile = "/api/playbook-dispatcher/v1/openapi.json"
 const apiShutdownTimeout = 10 * time.Second
 
 func init() {
-	openapi3.DefineStringFormat("uuid", `^[a-f0-9]{8}-[a-f0-9]{4}-[45][a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}$`)
+	openapi3.DefineStringFormat("uuid", `^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}$`)
+	openapi3.DefineStringFormat("sat-id-uuid", `^[a-f0-9]{8}-[a-f0-9]{4}-[45][a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}$`)
 	openapi3.DefineStringFormat("url", `^https?:\/\/.*$`)
 }
 

--- a/internal/api/main.go
+++ b/internal/api/main.go
@@ -32,7 +32,7 @@ const specFile = "/api/playbook-dispatcher/v1/openapi.json"
 const apiShutdownTimeout = 10 * time.Second
 
 func init() {
-	openapi3.DefineStringFormat("uuid", `^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}$`)
+	openapi3.DefineStringFormat("uuid", `^[a-f0-9]{8}-[a-f0-9]{4}-[45][a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}$`)
 	openapi3.DefineStringFormat("url", `^https?:\/\/.*$`)
 }
 

--- a/internal/api/tests/private/runsCreateV2_test.go
+++ b/internal/api/tests/private/runsCreateV2_test.go
@@ -167,7 +167,7 @@ var _ = Describe("runsCreate V2", func() {
 	})
 
 	It("creates a new satellite playbook run with a uuidv5 as the sat_id", func() {
-		recipient := uuid.New()
+		recipient := uuid.MustParse("9200e4a3-c97c-4021-9856-82fa4673e8d2")  // uuid gets used by cloud connector client mock
 		url := "http://example.com"
 		orgId := "5318290"
 
@@ -380,7 +380,7 @@ var _ = Describe("runsCreate V2", func() {
 		Entry(
 			"invalid Sattelite id",
 			`[{"recipient": "3831fec2-1875-432a-bb58-08e71908f0e6", "org_id": "5318290", "principal": "test-user", "url": "http://example.com", "name": "Red Hat Playbook", "recipient_config": {"sat_id": "abc", "sat_org_id": "1"}}]`,
-			`JSON string doesn't match the format \"uuid\"`,
+			`JSON string doesn't match the format \"sat-id-uuid\"`,
 		),
 		Entry(
 			"invalid Sattelite org id",

--- a/schema/private.openapi.yaml
+++ b/schema/private.openapi.yaml
@@ -237,9 +237,9 @@ components:
       type: object
       properties:
         sat_id:
-          description: Identifier of the Satellite instance
+          description: Identifier of the Satellite instance in the uuid v4/v5 format
           type: string
-          format: uuid
+          format: sat-id-uuid
           example: aa3b1faa-56f3-4d14-8258-615d11e20060
         sat_org_id:
           description: Identifier of the organization within Satellite


### PR DESCRIPTION
## What?
This PR adds support for sat_id uuidv5

[Jira Ticket](https://issues.redhat.com/browse/RHCLOUD-19427)

## Why?
The sat_id is a uuidv5. The internal api needs to support uuidv5 for satellite.

## How?
Updated regex to support both uuidv4 and uuidv5

## Testing
* Added 1 test to support this behavior
* Manual testing was done where a playbook was dispatched using the `internal/v2/dispatch` endpoint with a v5 uuid as the sat_id, and information on that playbook was viewed using the public api endpoint

## Anything Else?
[Information on uuidv4 and uuidv5](https://www.sohamkamani.com/uuid-versions-explained/)

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
