### PR TITLE
OrgID L2 Support #3 - [RHCLOUD-19300]

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ The value of each event is described by [a JSON schema](./schema/run.event.yaml)
     "payload": {
       "id": "6555d6f7-8dc1-4dec-9d1e-0ef8a02d7d43",
       "account": "901578",
+      "org_id": "5318290",
       "recipient": "dd018b96-da04-4651-84d1-187fa5c23f6c",
       "correlation_id": "fbf49ad9-ea79-41fb-9f6c-cb13307e993d",
       "service": "remediations",
@@ -229,7 +230,8 @@ In addition, each event contains the following headers:
 - `event_type` - the type of the event (see above)
 - `service` - the service that created the given playbook run
 - `status` - current of the playbook run
-- `account` - the account (tenant) the given playbook run belong to
+- `account` - a legacy identifier for the account (tenant) the given playbook run belong to (replaced by `org_id`)
+- `org_id` - the account (tenant) the given playbook run belong to
 
 The event headers make it possible to filter events without the need to parse the value of each event.
 

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -28,7 +28,7 @@ func clean(cmd *cobra.Command, args []string) error {
 		result := tx.Model(&dbModel.Run{}).
 			Where("runs.status", "running").
 			Where("runs.created_at + runs.timeout * interval '1 second' <= NOW()").
-			Select("id", "account", "correlation_id", "recipient").
+			Select("id", "account", "org_id", "correlation_id", "recipient").
 			Find(&dbRuns)
 
 		if result.Error != nil {
@@ -42,7 +42,7 @@ func clean(cmd *cobra.Command, args []string) error {
 
 		ids := make([]string, len(dbRuns))
 		for i, run := range dbRuns {
-			log.Infow("Updating timed-out run", "run_id", run.ID.String(), "account", run.Account, "correlation_id", run.CorrelationID.String(), "recipient", run.Recipient.String())
+			log.Infow("Updating timed-out run", "run_id", run.ID.String(), "account", run.Account, "org_id", run.OrgID, "correlation_id", run.CorrelationID.String(), "recipient", run.Recipient.String())
 			ids[i] = run.ID.String()
 		}
 

--- a/deploy/connect.yaml
+++ b/deploy/connect.yaml
@@ -279,7 +279,7 @@ objects:
 
         heartbeat.interval.ms: 600000
         heartbeat.topics.prefix: "__debezium-heartbeat-pd"
-        heartbeat.action.query: "INSERT INTO public.runs (id, account, recipient, correlation_id, url, service, timeout, created_at, updated_at) VALUES ('98875b33-b37e-4c35-be8b-d74f321bac28', '901578', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 'https://redhat.com', 'heartbeat', 3600, NOW(), NOW()) ON CONFLICT(id) DO UPDATE SET updated_at=NOW();"
+        heartbeat.action.query: "INSERT INTO public.runs (id, account, org_id, recipient, correlation_id, url, service, timeout, created_at, updated_at) VALUES ('98875b33-b37e-4c35-be8b-d74f321bac28', '901578', '5318290', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 'https://redhat.com', 'heartbeat', 3600, NOW(), NOW()) ON CONFLICT(id) DO UPDATE SET updated_at=NOW();"
 
 - apiVersion: apps/v1
   kind: Deployment

--- a/event-streams/connector.json
+++ b/event-streams/connector.json
@@ -33,6 +33,6 @@
 
         "heartbeat.interval.ms": 600000,
         "heartbeat.topics.prefix": "__debezium-heartbeat-pd",
-        "heartbeat.action.query": "INSERT INTO public.runs (id, account, recipient, correlation_id, url, service, timeout, created_at, updated_at) VALUES ('98875b33-b37e-4c35-be8b-d74f321bac28', '901578', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 'https://redhat.com', 'heartbeat', 3600, NOW(), NOW()) ON CONFLICT(id) DO UPDATE SET updated_at=NOW();"
+        "heartbeat.action.query": "INSERT INTO public.runs (id, account, org_id, recipient, correlation_id, url, service, timeout, created_at, updated_at) VALUES ('98875b33-b37e-4c35-be8b-d74f321bac28', '901578', '5318290', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 'https://redhat.com', 'heartbeat', 3600, NOW(), NOW()) ON CONFLICT(id) DO UPDATE SET updated_at=NOW();"
     }
 }

--- a/event-streams/src/main/java/com/redhat/cloud/platform/playbook_dispatcher/RunEventTransform.java
+++ b/event-streams/src/main/java/com/redhat/cloud/platform/playbook_dispatcher/RunEventTransform.java
@@ -34,6 +34,7 @@ public class RunEventTransform<T extends ConnectRecord<T>> implements Transforma
     static final String HEADER_SERVICE = "service";
     static final String HEADER_STATUS = "status";
     static final String HEADER_ACCOUNT = "account";
+    static final String HEADER_ORG_ID = "org_id";
 
     private static final String CONFIG_TOPIC = "topic";
     private static final String CONFIG_TABLE = "table";
@@ -113,7 +114,8 @@ public class RunEventTransform<T extends ConnectRecord<T>> implements Transforma
             .addString(HEADER_EVENT_TYPE, event.getEventType().value())
             .addString(HEADER_SERVICE, event.getPayload().getService())
             .addString(HEADER_STATUS, event.getPayload().getStatus().value())
-            .addString(HEADER_ACCOUNT, event.getPayload().getAccount());
+            .addString(HEADER_ACCOUNT, event.getPayload().getAccount())
+            .addString(HEADER_ORG_ID, event.getPayload().getOrgId());
     }
 
     private String transformKey(Struct key) {
@@ -143,6 +145,7 @@ public class RunEventTransform<T extends ConnectRecord<T>> implements Transforma
         final Payload payload = new Payload();
         payload.setId(input.getString("id"));
         payload.setAccount(input.getString("account"));
+        payload.setOrgId(input.getString("org_id"));
         payload.setRecipient(input.getString("recipient"));
         payload.setCorrelationId(input.getString("correlation_id"));
         payload.setService(input.getString("service"));

--- a/event-streams/src/main/java/com/redhat/cloud/platform/playbook_dispatcher/types/Payload.java
+++ b/event-streams/src/main/java/com/redhat/cloud/platform/playbook_dispatcher/types/Payload.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 @JsonPropertyOrder({
     "id",
     "account",
+    "org_id",
     "recipient",
     "correlation_id",
     "service",
@@ -46,6 +47,13 @@ public class Payload {
      */
     @JsonProperty("account")
     private String account;
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("org_id")
+    private String orgId;
     /**
      * 
      * (Required)
@@ -156,6 +164,26 @@ public class Payload {
     @JsonProperty("account")
     public void setAccount(String account) {
         this.account = account;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("org_id")
+    public String getOrgId() {
+        return orgId;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("org_id")
+    public void setOrgId(String orgId) {
+        this.orgId = orgId;
     }
 
     /**
@@ -390,6 +418,10 @@ public class Payload {
         sb.append('=');
         sb.append(((this.account == null)?"<null>":this.account));
         sb.append(',');
+        sb.append("orgId");
+        sb.append('=');
+        sb.append(((this.orgId == null)?"<null>":this.orgId));
+        sb.append(',');
         sb.append("recipient");
         sb.append('=');
         sb.append(((this.recipient == null)?"<null>":this.recipient));
@@ -454,6 +486,7 @@ public class Payload {
     public int hashCode() {
         int result = 1;
         result = ((result* 31)+((this.webConsoleUrl == null)? 0 :this.webConsoleUrl.hashCode()));
+        result = ((result* 31)+((this.orgId == null)? 0 :this.orgId.hashCode()));
         result = ((result* 31)+((this.url == null)? 0 :this.url.hashCode()));
         result = ((result* 31)+((this.timeout == null)? 0 :this.timeout.hashCode()));
         result = ((result* 31)+((this.labels == null)? 0 :this.labels.hashCode()));
@@ -480,7 +513,7 @@ public class Payload {
             return false;
         }
         Payload rhs = ((Payload) other);
-        return ((((((((((((((((this.webConsoleUrl == rhs.webConsoleUrl)||((this.webConsoleUrl!= null)&&this.webConsoleUrl.equals(rhs.webConsoleUrl)))&&((this.url == rhs.url)||((this.url!= null)&&this.url.equals(rhs.url))))&&((this.timeout == rhs.timeout)||((this.timeout!= null)&&this.timeout.equals(rhs.timeout))))&&((this.labels == rhs.labels)||((this.labels!= null)&&this.labels.equals(rhs.labels))))&&((this.createdAt == rhs.createdAt)||((this.createdAt!= null)&&this.createdAt.equals(rhs.createdAt))))&&((this.service == rhs.service)||((this.service!= null)&&this.service.equals(rhs.service))))&&((this.recipient == rhs.recipient)||((this.recipient!= null)&&this.recipient.equals(rhs.recipient))))&&((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name))))&&((this.correlationId == rhs.correlationId)||((this.correlationId!= null)&&this.correlationId.equals(rhs.correlationId))))&&((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.account == rhs.account)||((this.account!= null)&&this.account.equals(rhs.account))))&&((this.recipientConfig == rhs.recipientConfig)||((this.recipientConfig!= null)&&this.recipientConfig.equals(rhs.recipientConfig))))&&((this.status == rhs.status)||((this.status!= null)&&this.status.equals(rhs.status))))&&((this.updatedAt == rhs.updatedAt)||((this.updatedAt!= null)&&this.updatedAt.equals(rhs.updatedAt))));
+        return (((((((((((((((((this.webConsoleUrl == rhs.webConsoleUrl)||((this.webConsoleUrl!= null)&&this.webConsoleUrl.equals(rhs.webConsoleUrl)))&&((this.orgId == rhs.orgId)||((this.orgId!= null)&&this.orgId.equals(rhs.orgId))))&&((this.url == rhs.url)||((this.url!= null)&&this.url.equals(rhs.url))))&&((this.timeout == rhs.timeout)||((this.timeout!= null)&&this.timeout.equals(rhs.timeout))))&&((this.labels == rhs.labels)||((this.labels!= null)&&this.labels.equals(rhs.labels))))&&((this.createdAt == rhs.createdAt)||((this.createdAt!= null)&&this.createdAt.equals(rhs.createdAt))))&&((this.service == rhs.service)||((this.service!= null)&&this.service.equals(rhs.service))))&&((this.recipient == rhs.recipient)||((this.recipient!= null)&&this.recipient.equals(rhs.recipient))))&&((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name))))&&((this.correlationId == rhs.correlationId)||((this.correlationId!= null)&&this.correlationId.equals(rhs.correlationId))))&&((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.account == rhs.account)||((this.account!= null)&&this.account.equals(rhs.account))))&&((this.recipientConfig == rhs.recipientConfig)||((this.recipientConfig!= null)&&this.recipientConfig.equals(rhs.recipientConfig))))&&((this.status == rhs.status)||((this.status!= null)&&this.status.equals(rhs.status))))&&((this.updatedAt == rhs.updatedAt)||((this.updatedAt!= null)&&this.updatedAt.equals(rhs.updatedAt))));
     }
 
     public enum Status {

--- a/event-streams/src/test/java/com/redhat/cloud/platform/playbook_dispatcher/Factory.java
+++ b/event-streams/src/test/java/com/redhat/cloud/platform/playbook_dispatcher/Factory.java
@@ -15,6 +15,7 @@ class Factory {
         return new StructBuilder()
         .put("id", "b5c80cd3-8849-46a2-97e2-368cf62a1cda")
         .put("account", "0000001")
+        .put("org_id", "0000001-test")
         .put("recipient", "dd018b96-da04-4651-84d1-187fa5c23f6c")
         .put("correlation_id", "97b04495-68f0-4a41-93b9-d239c0a59b4f")
         .put("url", "http://example.com")

--- a/event-streams/src/test/java/com/redhat/cloud/platform/playbook_dispatcher/RunEventTransformParameterizedTest.java
+++ b/event-streams/src/test/java/com/redhat/cloud/platform/playbook_dispatcher/RunEventTransformParameterizedTest.java
@@ -74,6 +74,7 @@ public class RunEventTransformParameterizedTest {
         final SourceRecord result = transform.apply(this.record);
         assertEquals(result.headers().lastWithName(RunEventTransform.HEADER_EVENT_TYPE).value(), this.eventType);
         assertEquals(result.headers().lastWithName(RunEventTransform.HEADER_ACCOUNT).value(), "0000001");
+        assertEquals(result.headers().lastWithName(RunEventTransform.HEADER_ORG_ID).value(), "0000001-test");
         assertEquals(result.headers().lastWithName(RunEventTransform.HEADER_SERVICE).value(), "test");
         assertEquals(result.headers().lastWithName(RunEventTransform.HEADER_STATUS).value(), "success");
     }
@@ -87,6 +88,7 @@ public class RunEventTransformParameterizedTest {
         assertEquals(this.eventType, value.getEventType().value());
         assertEquals("b5c80cd3-8849-46a2-97e2-368cf62a1cda", value.getPayload().getId());
         assertEquals("0000001", value.getPayload().getAccount());
+        assertEquals("0000001-test", value.getPayload().getOrgId());
         assertEquals("dd018b96-da04-4651-84d1-187fa5c23f6c", value.getPayload().getRecipient());
         assertEquals("97b04495-68f0-4a41-93b9-d239c0a59b4f", value.getPayload().getCorrelationId());
         assertEquals("test", value.getPayload().getService());

--- a/examples/connector-local.json
+++ b/examples/connector-local.json
@@ -37,6 +37,6 @@
 
         "heartbeat.interval.ms": 60000,
         "heartbeat.topics.prefix": "__debezium-heartbeat-pd",
-        "heartbeat.action.query": "INSERT INTO public.runs (id, account, recipient, correlation_id, url, service, timeout, created_at, updated_at) VALUES ('98875b33-b37e-4c35-be8b-d74f321bac28', '901578', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 'https://redhat.com', 'heartbeat', 3600, NOW(), NOW()) ON CONFLICT(id) DO UPDATE SET updated_at=NOW();"
+        "heartbeat.action.query": "INSERT INTO public.runs (id, account, org_id, recipient, correlation_id, url, service, timeout, created_at, updated_at) VALUES ('98875b33-b37e-4c35-be8b-d74f321bac28', '901578', '5318290', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 'https://redhat.com', 'heartbeat', 3600, NOW(), NOW()) ON CONFLICT(id) DO UPDATE SET updated_at=NOW();"
     }
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/RedHatInsights/tenant-utils v1.0.0
-	github.com/aws/aws-sdk-go v1.36.28
+	github.com/aws/aws-sdk-go v1.38.51
 	github.com/confluentinc/confluent-kafka-go v1.5.2
 	github.com/deepmap/oapi-codegen v1.4.2
 	github.com/getkin/kin-openapi v0.36.0
@@ -20,7 +20,7 @@ require (
 	github.com/prometheus/client_golang v1.12.1
 	github.com/qri-io/jsonschema v0.2.0
 	github.com/redhatinsights/app-common-go v1.2.0
-	github.com/redhatinsights/platform-go-middlewares v0.7.1-0.20201009171810-b73c54b47a2d
+	github.com/redhatinsights/platform-go-middlewares v0.17.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.1
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/aws/aws-sdk-go v1.17.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.34.2/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.36.28 h1:JVRN7BZgwQ31SQCBwG5QM445+ynJU0ruKu+miFIijYY=
 github.com/aws/aws-sdk-go v1.36.28/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go v1.38.51 h1:aKQmbVbwOCuQSd8+fm/MR3bq0QOsu9Q7S+/QEND36oQ=
+github.com/aws/aws-sdk-go v1.38.51/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go-v2 v1.8.0/go.mod h1:xEFuWz+3TYdlPRuo+CqATbeDWIWyaT5uAPwPaWtgse0=
 github.com/aws/aws-sdk-go-v2 v1.9.2/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
 github.com/aws/aws-sdk-go-v2/config v1.6.0/go.mod h1:TNtBVmka80lRPk5+S9ZqVfFszOQAGJJ9KbT3EM3CHNU=
@@ -921,6 +923,8 @@ github.com/redhatinsights/app-common-go v1.2.0 h1:Z4TxbamehwIHdgK0GI7VDDv0q9mhaH
 github.com/redhatinsights/app-common-go v1.2.0/go.mod h1:SqgG5JkX/RNlk2d+sXamIFxhOIvWLgCBr8uK6q70ESk=
 github.com/redhatinsights/platform-go-middlewares v0.7.1-0.20201009171810-b73c54b47a2d h1:uxm5aXj3SYrAu3beL0+8VLYHA7RPhvoX47NQgBxVPCA=
 github.com/redhatinsights/platform-go-middlewares v0.7.1-0.20201009171810-b73c54b47a2d/go.mod h1:g//UN9p5sxgIoZfRyyiRy+rAw1/GMqkZ4hWUFcEC71A=
+github.com/redhatinsights/platform-go-middlewares v0.17.0 h1:upjyS2Fq+yGio0N8TrZWha6ZzhidIkRROM0QnDqpiMk=
+github.com/redhatinsights/platform-go-middlewares v0.17.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/internal/api/controllers/public/conversions.go
+++ b/internal/api/controllers/public/conversions.go
@@ -10,6 +10,7 @@ import (
 const (
 	fieldId            = "id"
 	fieldAccount       = "account"
+	fieldOrgId         = "org_id"
 	fieldRecipient     = "recipient"
 	fieldUrl           = "url"
 	fieldLabels        = "labels"
@@ -29,12 +30,13 @@ const (
 )
 
 var (
-	runFields     = utils.IndexStrings(fieldId, fieldAccount, fieldRecipient, fieldUrl, fieldLabels, fieldTimeout, fieldStatus, fieldCreatedAt, fieldUpdatedAt, fieldService, fieldCorrelationId, fieldName, fieldWebConsoleUrl)
+	runFields     = utils.IndexStrings(fieldId, fieldAccount, fieldOrgId, fieldRecipient, fieldUrl, fieldLabels, fieldTimeout, fieldStatus, fieldCreatedAt, fieldUpdatedAt, fieldService, fieldCorrelationId, fieldName, fieldWebConsoleUrl)
 	runHostFields = utils.IndexStrings(fieldHost, fieldRun, fieldStatus, fieldStdout, fieldLinks, fieldInventoryId)
 )
 
 var defaultRunFields = []string{
 	fieldId,
+	fieldOrgId,
 	fieldRecipient,
 	fieldUrl,
 	fieldLabels,
@@ -58,6 +60,9 @@ func dbRuntoApiRun(r *dbModel.Run, fields []string) *Run {
 		case fieldAccount:
 			value := Account(r.Account)
 			run.Account = &value
+		case fieldOrgId:
+			value := OrgId(r.OrgID)
+			run.OrgId = &value
 		case fieldRecipient:
 			run.Recipient = (*RunRecipient)(convertUuid(r.Recipient))
 		case fieldUrl:

--- a/internal/api/controllers/public/runHostsList.go
+++ b/internal/api/controllers/public/runHostsList.go
@@ -29,7 +29,7 @@ func (this *controllers) ApiRunHostsList(ctx echo.Context, params ApiRunHostsLis
 		WithContext(ctx.Request().Context()).
 		Table("run_hosts").
 		Joins("INNER JOIN runs on runs.id = run_hosts.run_id").
-		Where("runs.account = ?", identity.Identity.AccountNumber)
+		Where("runs.org_id = ?", identity.Identity.OrgID)
 
 	permissions := middleware.GetPermissions(ctx)
 	if allowedServices := rbac.GetPredicateValues(permissions, "service"); len(allowedServices) > 0 {

--- a/internal/api/controllers/public/runsList.go
+++ b/internal/api/controllers/public/runsList.go
@@ -51,7 +51,7 @@ func (this *controllers) ApiRunsList(ctx echo.Context, params ApiRunsListParams)
 	db := this.database.WithContext(ctx.Request().Context())
 
 	// tenant isolation
-	queryBuilder := db.Table("runs").Where("account = ?", identity.Identity.AccountNumber)
+	queryBuilder := db.Table("runs").Where("org_id = ?", identity.Identity.OrgID)
 
 	// rbac
 	permissions := middleware.GetPermissions(ctx)

--- a/internal/api/main.go
+++ b/internal/api/main.go
@@ -84,14 +84,18 @@ func Start(
 	}
 
 	var translator tenantid.Translator
-	if cfg.GetString("tenant.translator.impl") == "impl" {
+	switch cfg.GetString("tenant.translator.impl") {
+	case "impl":
 		translator = tenantid.NewTranslator(
 			fmt.Sprintf("%s://%s:%s", cfg.Get("tenant.translator.scheme"), cfg.Get("tenant.translator.host"), cfg.Get("tenant.translator.port")),
 			tenantid.WithTimeout(cfg.GetDuration("tenant.translator.timeout")*time.Second),
 			tenantid.WithMetrics(),
 		)
-	} else {
+	case "dynamic-mock":
 		translator = utils.NewDynamicMockTranslator()
+		log.Warn("Using dynamic mock TenantIDTranslator")
+	default:
+		translator = tenantid.NewTranslatorMock()
 		log.Warn("Using mock TenantIDTranslator")
 	}
 

--- a/internal/api/middleware/logger.go
+++ b/internal/api/middleware/logger.go
@@ -28,7 +28,7 @@ func RequestLogger(next echo.HandlerFunc) echo.HandlerFunc {
 		if identity, ok := c.Request().Context().Value(identityMiddleware.Key).(identityMiddleware.XRHID); ok {
 			log = log.With(
 				"account", identity.Identity.AccountNumber,
-				"org_id", identity.Identity.Internal.OrgID,
+				"org_id", identity.Identity.OrgID,
 			)
 		}
 

--- a/internal/api/tests/public/runsList_test.go
+++ b/internal/api/tests/public/runsList_test.go
@@ -203,6 +203,7 @@ var _ = Describe("runsList", func() {
 
 				data[3].Recipient = uuid.MustParse("64aeb237-d46d-494e-98e3-b48fc5c78bf1")
 				data[3].Account = "9999999999"
+				data[3].OrgID = "9999999999-test"
 
 				Expect(db().Create(&data).Error).ToNot(HaveOccurred())
 			})

--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -84,7 +84,7 @@ func Get() *viper.Viper {
 	options.SetDefault("rbac.scheme", "http")
 	options.SetDefault("rbac.timeout", 10)
 
-	options.SetDefault("tenant.translator.impl", "mock")
+	options.SetDefault("tenant.translator.impl", "dynamic-mock")
 	options.SetDefault("tenant.translator.host", "localhost")
 	options.SetDefault("tenant.translator.scheme", "http")
 	options.SetDefault("tenant.translator.port", "8892")

--- a/internal/common/utils/test/factories.go
+++ b/internal/common/utils/test/factories.go
@@ -81,6 +81,7 @@ func NewRunWithStatus(account string, status string) dbModel.Run {
 	return dbModel.Run{
 		ID:            uuid.New(),
 		Account:       account,
+		OrgID:         account + "-test",
 		Recipient:     uuid.New(),
 		CorrelationID: uuid.New(),
 		URL:           "http://example.com",

--- a/internal/common/utils/test/utils.go
+++ b/internal/common/utils/test/utils.go
@@ -12,7 +12,7 @@ import (
 )
 
 func IdentityHeaderMinimal(account string) string {
-	data := fmt.Sprintf(`{"identity":{"internal":{"org_id":"12345"},"account_number":"%s","user":{},"type":"User"}}`, account)
+	data := fmt.Sprintf(`{"identity":{"internal":{"org_id":"%s"},"account_number":"%s","user":{},"type":"User"}}`, account+"-test", account)
 	return base64.StdEncoding.EncodeToString([]byte(data))
 }
 

--- a/schema/run.event.yaml
+++ b/schema/run.event.yaml
@@ -17,6 +17,8 @@ properties:
         type: string
       account:
         type: string
+      org_id:
+        type: string
       recipient:
         type: string
       correlation_id:
@@ -60,6 +62,7 @@ properties:
     required:
       - id
       - account
+      - org_id
       - recipient
       - correlation_id
       - service


### PR DESCRIPTION
## What?
Add `org_id` to logging and queries

## Why?
Part of OrgID Level 2 Support

## How?
- [x] add org_id to public API responses
- [x] change public API to use org_id in queries
- [x] use org_id in logging
- [x] add org_id to event stream (header and payload)
- [x] use org_id column in response consumer queries

## Testing
Updated existing tests to use org_id

## Anything Else?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
