### PR TITLE
add a connector check cronjob

### DIFF
--- a/deploy/connect.yaml
+++ b/deploy/connect.yaml
@@ -52,6 +52,11 @@ parameters:
 - name: RDS_CACERT
   value: rdscacert
 
+- name: CONNECTOR_CHECK_SCHEDULE
+  value: "0 * * * *"
+- name: CONNECTOR_CHECK_SUSPEND
+  value: 'false'
+
 objects:
 - apiVersion: v1
   kind: ConfigMap
@@ -338,6 +343,47 @@ objects:
     selector:
       strimzi.io/kind: Kafka
     type: ClusterIP
+
+- apiVersion: batch/v1
+  kind: CronJob
+  metadata:
+    labels:
+      app: playbook-dispatcher
+    name: playbook-dispatcher-connector-check
+  spec:
+    schedule: ${CONNECTOR_CHECK_SCHEDULE}
+    concurrencyPolicy: Replace
+    failedJobsHistoryLimit: 1
+    successfulJobsHistoryLimit: 1
+    suspend: ${{CONNECTOR_CHECK_SUSPEND}}
+    jobTemplate:
+      spec:
+        template:
+          metadata:
+            labels:
+              app: playbook-dispatcher
+              pod: playbook-dispatcher-connector-check
+          spec:
+            restartPolicy: OnFailure
+            containers:
+            - command:
+              - /bin/sh
+              - /check-connectors.sh
+              env:
+              - name: CONNECT_HOST
+                value: playbook-dispatcher-connect-connect-api
+              - name: CONNECT_PORT
+                value: "8083"
+              image: ${KAFKA_CONNECT_IMAGE}:${IMAGE_TAG}
+              name: playbook-dispatcher-connector-check
+              resources:
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+                requests:
+                  cpu: 100m
+                  memory: 64Mi
+
 
 # this secrect is only used in ephemeral for testing
 - apiVersion: v1

--- a/event-streams/check-connectors.sh
+++ b/event-streams/check-connectors.sh
@@ -2,6 +2,6 @@
 
 # https://rmoff.net/2019/06/06/automatically-restarting-failed-kafka-connect-tasks/
 
-curl -s "http://localhost:8083/connectors?expand=status" | \
+curl -s "http://${CONNECT_HOST:-localhost}:${CONNECT_PORT:-8083}/connectors?expand=status" | \
   jq -c -M 'map({name: .status.name } +  {tasks: .status.tasks}) | .[] | {task: ((.tasks[]) + {name: .name})}  | select(.task.state=="FAILED") | {name: .task.name, task_id: .task.id|tostring} | ("/connectors/"+ .name + "/tasks/" + .task_id + "/restart")' | \
   xargs -I{connector_and_task} curl -v -X POST "http://localhost:8083"\{connector_and_task\}


### PR DESCRIPTION
## What?
A cronjob that periodically checks the Kafka connector tasks and restarts any failed ones.

## Why?
Sometimes a connector task may fail. Due to lack of implementation of https://github.com/strimzi/strimzi-kafka-operator/issues/2621 Strimzi operator does not do anything about failed tasks. This cronjob is a workaround.

## How?
An existing script is reused.

## Testing
Tested manually in the ephemeral environment

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
