### PR TITLE
hotfix for the generated code escaping ampersand with unicode in url [RHCLOUD-19952]

### DIFF
--- a/internal/api/connectors/cloudConnector.go
+++ b/internal/api/connectors/cloudConnector.go
@@ -63,6 +63,9 @@ func NewConnectorClientWithHttpRequestDoer(cfg *viper.Viper, doer HttpRequestDoe
 					req.Header.Set(constants.HeaderCloudConnectorOrgID, ctx.Value(orgIDKey).(string))
 				}
 
+				// hotfix for the generated code escaping ampersands in string
+				req.Body = utils.ReplaceAmpersand(req.Body)
+
 				return nil
 			},
 		},

--- a/internal/api/connectors/cloudConnector.go
+++ b/internal/api/connectors/cloudConnector.go
@@ -85,15 +85,13 @@ func NewConnectorClient(cfg *viper.Viper) CloudConnectorClient {
 }
 
 func encodedBody(body PostMessageJSONRequestBody) (io.Reader, error) {
-	var bodyReader io.Reader
 	buf := &bytes.Buffer{}
 	encoder := json.NewEncoder(buf)
 	encoder.SetEscapeHTML(false)
 	if err := encoder.Encode(body); err != nil {
 		return nil, err
 	}
-	bodyReader = bytes.NewReader(buf.Bytes())
-	return bodyReader, nil
+	return buf, nil
 }
 
 func (this *cloudConnectorClientImpl) SendCloudConnectorRequest(

--- a/internal/api/connectors/cloudConnector_test.go
+++ b/internal/api/connectors/cloudConnector_test.go
@@ -25,6 +25,10 @@ var (
 	satDirective     = "playbook-sat"
 )
 
+type CustomUrlType struct {
+	Payload json.RawMessage
+}
+
 func ansibleMetadata(correlationId uuid.UUID) map[string]string {
 	return map[string]string{
 		"crc_dispatcher_correlation_id": correlationId.String(),
@@ -230,9 +234,11 @@ var _ = Describe("Cloud Connector", func() {
 
 		bytes, err := ioutil.ReadAll(doer.Request.Body)
 		Expect(err).ToNot(HaveOccurred())
+		parsedRequest := &CustomUrlType{}
+		err = json.Unmarshal(bytes, parsedRequest)
+		Expect(err).ToNot(HaveOccurred())
 
-		expectedRequestBody := fmt.Sprintf(`{"account":"1234","directive":"playbook","metadata":{"crc_dispatcher_correlation_id":"%s","response_interval":"60","return_url":"http://example.com/return"},"payload":"http://example.com/?field1=test&field2=test2&field3","recipient":"%s"}`, correlationId.String(), recipient.String())
-		Expect(string(bytes)).To(Equal(expectedRequestBody))
+		Expect(string(parsedRequest.Payload)).To(Equal("\"http://example.com/?field1=test&field2=test2&field3\""))
 	})
 
 	Describe("connection status", func() {

--- a/internal/common/utils/misc.go
+++ b/internal/common/utils/misc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/url"
 	"strings"
@@ -108,4 +109,16 @@ func LoadSchemas(cfg *viper.Viper, schemaNames []string) (schemas []*jsonschema.
 		schemas = append(schemas, &schema)
 	}
 	return
+}
+
+func ReplaceAmpersand(body io.Reader) io.ReadCloser {
+	bodyBytes, err := io.ReadAll(body)
+	DieOnError(err)
+
+	bodyString := string(bodyBytes)
+
+	bodyString = strings.Replace(bodyString, "\\u0026", "&", -1) //Replace all the ampersand unicode in the body
+	stringReader := strings.NewReader(bodyString)
+
+	return io.NopCloser(stringReader)
 }

--- a/internal/common/utils/misc.go
+++ b/internal/common/utils/misc.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/url"
 	"strings"
@@ -109,16 +108,4 @@ func LoadSchemas(cfg *viper.Viper, schemaNames []string) (schemas []*jsonschema.
 		schemas = append(schemas, &schema)
 	}
 	return
-}
-
-func ReplaceAmpersand(body io.Reader) io.ReadCloser {
-	bodyBytes, err := io.ReadAll(body)
-	DieOnError(err)
-
-	bodyString := string(bodyBytes)
-
-	bodyString = strings.Replace(bodyString, "\\u0026", "&", -1) //Replace all the ampersand unicode in the body
-	stringReader := strings.NewReader(bodyString)
-
-	return io.NopCloser(stringReader)
 }


### PR DESCRIPTION
## What?
By default, `json.Marshal()` replaced ampersand (`&`) with unicode.
The golang `json` library does provide a function to prohibit this behaviour (`encoder.SetEscapeHTML`), however, our generated code does not make use of this functionality. Therefore, we end up with a faulty url where the ampersands are replaced with their unicode values.

[Jira Ticket](https://issues.redhat.com/browse/RHCLOUD-19952)

## Why?
:fire: :fire: :fire:

## How?
~I wrote a simple `ReplaceAmpersand` function, that replaces the ampersand unicode with its actual character value right before the request is sent to Cloud Connector.
There maybe a better way to accomplish this end-goal by directly replacing the `PostMessage` method of the client interface, but this is the simplest way I can think of right now that doesn't require a big refactoring of the cloud-connector client.~

We are now using the `PostMessageWithBodyWithResponse` method to pass the `io.Reader` body directly to the generated code. This way, we are able to use the `encoder.SetEscapeHTML` method provided by the golang json library to not escape the ampersands with unicode.

## Testing
One test was added to demonstrate the behavior.

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
