### PR TITLE
[fix] kafka ca cert

### DIFF
--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -106,11 +106,13 @@ func Get() *viper.Viper {
 			options.Set("kafka.sasl.password", *broker.Sasl.Password)
 			options.Set("kafka.sasl.mechanism", *broker.Sasl.SaslMechanism)
 			options.Set("kafka.sasl.protocol", *broker.Sasl.SecurityProtocol)
+		}
+		if broker.Cacert != nil {
 			caPath, err := cfg.KafkaCa(broker)
 			if err != nil {
 				panic("Kafka CA failed to write")
 			}
-			options.Set("kafka.capath", caPath)
+			options.Set("KafkaCA", caPath)
 		}
 
 		options.SetDefault("log.cw.accessKeyId", cfg.Logging.Cloudwatch.AccessKeyId)

--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -112,7 +112,7 @@ func Get() *viper.Viper {
 			if err != nil {
 				panic("Kafka CA failed to write")
 			}
-			options.Set("KafkaCA", caPath)
+			options.Set("kafka.capath", caPath)
 		}
 
 		options.SetDefault("log.cw.accessKeyId", cfg.Logging.Cloudwatch.AccessKeyId)


### PR DESCRIPTION
We don't have a cert in managed kafka but we do in fedramp. We need to
be more forgivable here

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Make a kafkaCA not a requirement

## Why?
The kafkaCA is not in managed kafka but is in fedramp. We need to skip it if we dont' have it.

## How?
Separate the if statement

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
