### PR TITLE
[fix] connect to managed kafka with ssl

### DIFF
--- a/deploy/connect-rhosak.yaml
+++ b/deploy/connect-rhosak.yaml
@@ -71,6 +71,8 @@ objects:
       offset.storage.replication.factor: ${KAFKA_REPLICATION_FACTOR}
       status.storage.replication.factor: ${KAFKA_REPLICATION_FACTOR}
       config.storage.replication.factor: ${KAFKA_REPLICATION_FACTOR}
+    tls:
+      trustedCertificates: []
     authentication:
       # this config is specific to PLAIN sasl mechanism
       type: ${KAFKA_SASL_MECHANISM}


### PR DESCRIPTION
I'm pretty sure this is how we set that property based on the schema
reference

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Add a tls stanza to the connect rhosak config

## Why?
The connection by default is plaintext and we need it to be ssl. As far as I can tell from reading [these docs](https://strimzi.io/docs/operators/in-development/configuring.html#con-common-configuration-trusted-certificates-reference) this is how we do it.

## How?
Add a couple lines to the connect-rhosak.yml

## Testing
We'll know if it works when it gets to stage. i did run `oc processg` against it and it succeeded.

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
