### PR TITLE
Revert "[fix] add the security protocol to the rhosak deploy"

### DIFF
--- a/deploy/connect-rhosak.yaml
+++ b/deploy/connect-rhosak.yaml
@@ -18,9 +18,7 @@ parameters:
 - name: KAFKA_USERNAME
   value: kafkauser
 - name: KAFKA_SASL_MECHANISM
-  value: plain
-- name: KAFKA_SASL_SECURITY_PROTOCOL
-  value: sasl_ssl
+  value: plain 
 - name: VERSION
   value: '2.7.1'
 - name: NUM_REPLICAS
@@ -73,10 +71,8 @@ objects:
       offset.storage.replication.factor: ${KAFKA_REPLICATION_FACTOR}
       status.storage.replication.factor: ${KAFKA_REPLICATION_FACTOR}
       config.storage.replication.factor: ${KAFKA_REPLICATION_FACTOR}
-      security.protocol: ${KAFKA_SASL_SECURITY_PROTOCOL}
-      producer.security.protocol: ${KAFKA_SASL_SECURITY_PROTOCOL}
-      consumer.security.protocol: ${KAFKA_SASL_SECURITY_PROTOCOL}
-      admin.security.protocol: ${KAFKA_SASL_SECURITY_PROTOCOL}
+    tls:
+      trustedCertificates: []
     authentication:
       # this config is specific to PLAIN sasl mechanism
       type: ${KAFKA_SASL_MECHANISM}


### PR DESCRIPTION
It looks like the previous iteration of this DID work. Not sure when it did what it was supposed to do but now there is a pod out there that connects. 

Reverts RedHatInsights/playbook-dispatcher#243