### PR TITLE
Reject empty archives before validation [RHCLOUD-20256]

### DIFF
--- a/internal/validator/handler.go
+++ b/internal/validator/handler.go
@@ -154,7 +154,7 @@ func (this *handler) validationSteps(
 }
 
 func (this *handler) validateRequest(request *messageModel.IngressValidationRequest) (err error) {
-	if request.Size > cfg.GetInt64("artifact.max.size") {
+	if request.Size == 0 || request.Size > cfg.GetInt64("artifact.max.size") {
 		return fmt.Errorf("Rejecting payload due to file size: %d", request.Size)
 	}
 

--- a/internal/validator/handler_test.go
+++ b/internal/validator/handler_test.go
@@ -45,6 +45,15 @@ var _ = Describe("Handler", func() {
 			err := instance.validateRequest(req)
 			Expect(err).To(HaveOccurred())
 		})
+
+		It("Rejects empty archives", func() {
+			req := &messageModel.IngressValidationRequest{
+				Size: 0,
+			}
+
+			err := instance.validateRequest(req)
+			Expect(err).To(HaveOccurred())
+		})
 	})
 
 	Describe("Validation", func() {


### PR DESCRIPTION
## What?
Empty archives are not valid. This PR rejects such archives before we start the validation process.

[Jira ticket](https://issues.redhat.com/browse/RHCLOUD-20256)

## Why?
This is triggering s3-fetch alerts.

## How?
Added a check for archive size that rejects on `request.Size == 0`

## Testing
* added 1 test

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
