### PR TITLE
QUICK-FIX Update Cancelation url to be an empty string

### DIFF
--- a/internal/api/dispatch/impl.go
+++ b/internal/api/dispatch/impl.go
@@ -114,6 +114,7 @@ func (this *dispatchManager) ProcessRun(ctx context.Context, orgID string, servi
 
 func (this *dispatchManager) ProcessCancel(ctx context.Context, orgID string, cancel generic.CancelInput) (runID, correlationID uuid.UUID, err error) {
 	var run db.Run
+	payload := ""
 
 	if err := this.db.First(&run, cancel.RunId).Error; err != nil {
 		instrumentation.PlaybookRunCancelError(ctx, err)
@@ -148,7 +149,7 @@ func (this *dispatchManager) ProcessCancel(ctx context.Context, orgID string, ca
 		ctx,
 		orgID,
 		run.Recipient,
-		nil,
+		&payload,
 		string(protocol.GetDirective()),
 		signalMetadata,
 	)


### PR DESCRIPTION
## What?
Update Cancelation url to be an empty string.

## Why?
We are currently setting the url to be nil for the Cancelation endpoint which is causing Cloud Connector to error and not send the Cancelation request onto the playbook runner.

## How?
Change cancelation url from nil to empty string by adding an empty string variable called payload.

## Testing
Did you add any tests for the change?

## Anything Else?
JIRA: https://issues.redhat.com/browse/RHCLOUD-20841

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
