### PR TITLE
[fix] Add the kafka topic prefix

### DIFF
--- a/deploy/connect-rhosak.yaml
+++ b/deploy/connect-rhosak.yaml
@@ -17,6 +17,8 @@ parameters:
   value: kafkauser
 - name: KAFKA_SASL_MECHANISM
   value: plain 
+- name: KAFKA_TOPIC_PREFIX
+  value: ""
 - name: DB_HOSTNAME
   value: '${file:/opt/kafka/external-configuration/playbook-dispatcher-db/db.host}'
 - name: DB_PORT
@@ -194,9 +196,9 @@ objects:
       group.id: playbook-dispatcher-connect
       config.providers: file
       config.providers.file.class: com.redhat.insights.kafka.config.providers.PlainFileConfigProvider
-      offset.storage.topic: playbook-dispatcher-connect-config
-      status.storage.topic: playbook-dispatcher-connect-status
-      config.storage.topic: playbook-dispatcher-connect-offsets
+      offset.storage.topic: ${KAFKA_TOPIC_PREFIX}playbook-dispatcher-connect-config
+      status.storage.topic: ${KAFKA_TOPIC_PREFIX}playbook-dispatcher-connect-status
+      config.storage.topic: ${KAFKA_TOPIC_PREFIX}playbook-dispatcher-connect-offsets
       offset.storage.replication.factor: ${KAFKA_REPLICATION_FACTOR}
       status.storage.replication.factor: ${KAFKA_REPLICATION_FACTOR}
       config.storage.replication.factor: ${KAFKA_REPLICATION_FACTOR}
@@ -282,7 +284,7 @@ objects:
         transforms: transformRunEvent
         transforms.transformRunEvent.type: com.redhat.cloud.platform.playbook_dispatcher.RunEventTransform
         transforms.transformRunEvent.table: runs
-        transforms.transformRunEvent.topic: platform.playbook-dispatcher.runs
+        transforms.transformRunEvent.topic: ${KAFKA_TOPIC_PREFIX}platform.playbook-dispatcher.runs
 
         errors.tolerance: all
         errors.retry.delay.max.ms: 30000


### PR DESCRIPTION
In managed kakfa we use a prefix. This needs to be added to the
configuration so we read from the right topics

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?

Add the kafka topic prefix

## Why?

We need this because managed kafka uses a prefix right now. Without it, we won't 
be reading from the right topics.

## How?

Just add the param and prefix the topics with it

## Testing

Ran this through `oc process` to verify it got filled out properly

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
