### PR TITLE
[fix] increase linting check timeout

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -31,6 +31,7 @@ jobs:
 
           # Optional: golangci-lint command line arguments.
           # args: --issues-exit-code=0
+          args: --timeout=2m
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true


### PR DESCRIPTION
The action has been failing for a while due to it being a bit slow.
increase the timeout by 1m

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?

Increase the timeout for the golang-ci lint action

## Why?

The current timeout is too low right now, resulting in failures

## How?

Add an arg to the workflow file

## Testing

The test in the PR will let us know if this is working.

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
