### PR TITLE
[test] use managed kafka when doing dispatcher tests

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -42,6 +42,7 @@ source $CICD_ROOT/cji_smoke_test.sh
 bonfire deploy playbook-dispatcher cloud-connector \
     --source=appsre \
     --ref-env ${REF_ENV} \
+    --pool managed-kafka \
     --set-template-ref ${COMPONENT_NAME}=${GIT_COMMIT} \
     --set-image-tag ${IMAGE_DISPATCHER}=${IMAGE_TAG} \
     --set-image-tag ${IMAGE_CONNECT}=${IMAGE_TAG} \

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -28,7 +28,8 @@ IMAGE_CONNECT="quay.io/cloudservices/playbook-dispatcher-connect"
 source $CICD_ROOT/build.sh
 
 # IMAGE is set to the Connect image, setting dispatcher image as an extra arg
-EXTRA_DEPLOY_ARGS="--set-image-tag ${IMAGE_DISPATCHER}=${IMAGE_TAG}"
+# use managed-kafka due to limitations in configuring kafka connect
+EXTRA_DEPLOY_ARGS="--set-image-tag ${IMAGE_DISPATCHER}=${IMAGE_TAG} --pool managed-kafka"
 
 # Deploy to an ephemeral environment
 source $CICD_ROOT/deploy_ephemeral_env.sh


### PR DESCRIPTION
Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?

Use the managed kafka pool when running tests

## Why?

because the connect app is either managed kafka or not. It doesn't easily switch using
any flags. Since we have to move to managed kafka, it makes sense to set the bonfire
pool to use managed kafka in ephemeral

## How?

Add a param to the bonfire execution in pr_check.sh

## Testing

the pr will test itself

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
