### PR TITLE
Use correct v2 response in GetConnectionStatus

### DIFF
--- a/internal/api/connectors/cloudConnector.gen.go
+++ b/internal/api/connectors/cloudConnector.gen.go
@@ -31,6 +31,8 @@ type ConnectionListAccountResponse struct {
 	PaginatedResponseMeta `yaml:",inline"`
 	// Embedded struct due to allOf(#/components/schemas/PaginatedResponseLinks)
 	PaginatedResponseLinks `yaml:",inline"`
+	// Embedded fields due to inline allOf schema
+	Data *[]string `json:"data,omitempty"`
 }
 
 // ConnectionListByAccountResponseV2 defines model for ConnectionListByAccountResponseV2.
@@ -39,6 +41,8 @@ type ConnectionListByAccountResponseV2 struct {
 	PaginatedResponseMeta `yaml:",inline"`
 	// Embedded struct due to allOf(#/components/schemas/PaginatedResponseLinks)
 	PaginatedResponseLinks `yaml:",inline"`
+	// Embedded fields due to inline allOf schema
+	Data *[]ConnectionV2 `json:"data,omitempty"`
 }
 
 // ConnectionListResponse defines model for ConnectionListResponse.
@@ -47,6 +51,11 @@ type ConnectionListResponse struct {
 	PaginatedResponseMeta `yaml:",inline"`
 	// Embedded struct due to allOf(#/components/schemas/PaginatedResponseLinks)
 	PaginatedResponseLinks `yaml:",inline"`
+	// Embedded fields due to inline allOf schema
+	Data *[]struct {
+		Account     *string   `json:"account,omitempty"`
+		Connections *[]string `json:"connections,omitempty"`
+	} `json:"data,omitempty"`
 }
 
 // ConnectionPingResponse defines model for ConnectionPingResponse.
@@ -88,6 +97,8 @@ type ConnectionStatusResponse struct {
 type ConnectionStatusResponseV2 struct {
 	// Embedded struct due to allOf(#/components/schemas/ConnectionV2)
 	ConnectionV2 `yaml:",inline"`
+	// Embedded fields due to inline allOf schema
+	Status *ConnectionStatus `json:"status,omitempty"`
 }
 
 // ConnectionV2 defines model for ConnectionV2.

--- a/internal/api/connectors/cloudConnector.go
+++ b/internal/api/connectors/cloudConnector.go
@@ -154,12 +154,5 @@ func (this *cloudConnectorClientImpl) GetConnectionStatus(
 		return "", err
 	}
 
-	// The Status field is not correctly being generated in the ConnectionStatusResponseV2 struct
-	// Unmarshaling using ConnectionStatusResponse as a work-around until the openapi codegen is fixed
-	connectionStatusResponse := ConnectionStatusResponse{}
-	if err := json.Unmarshal(res.Body, &connectionStatusResponse); err != nil {
-		return "", err
-	}
-
-	return *connectionStatusResponse.Status, nil
+	return *res.JSON200.Status, nil
 }


### PR DESCRIPTION
## What?
Switching to use the correct v2 struct in GetConnectionStatus

## Why?
The bug mentioned in [RHCLOUD-20714](https://issues.redhat.com/browse/RHCLOUD-20714) has been fixed, so now this struct contains the `Status` field that we need.

## How?
Change from manually unmarshaling into the v1 struct to access the `Status` field to using the v2.

## Testing
Nothing new to test

## Anything Else?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
