### PR TITLE
tests: fix the connect image to use proper kafka in eph

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -39,12 +39,14 @@ IQE_MARKER_EXPRESSION="smoke"
 source $CICD_ROOT/cji_smoke_test.sh
 
 # Re-deploy Playbook Dispatcher to an ephemeral environment, this time enabling the communication with Cloud Connector
+# The connect image template is overridden to make use of the connect.yaml file from before managed kafka was put in place
 bonfire deploy playbook-dispatcher cloud-connector \
     --source=appsre \
     --ref-env ${REF_ENV} \
     --set-template-ref ${COMPONENT_NAME}=${GIT_COMMIT} \
     --set-image-tag ${IMAGE_DISPATCHER}=${IMAGE_TAG} \
     --set-image-tag ${IMAGE_CONNECT}=${IMAGE_TAG} \
+    --set-template-ref ${IMAGE_CONNECT}=047e256da507f29d0e0ae803a4b1d688eb74a2cb \
     --namespace ${NAMESPACE} \
     --timeout ${DEPLOY_TIMEOUT} \
     --set-parameter playbook-dispatcher/CLOUD_CONNECTOR_IMPL=impl

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -4,6 +4,7 @@
 # --------------------------------------------
 APP_NAME="playbook-dispatcher"  # name of app-sre "application" folder this component lives in
 COMPONENT_NAME="playbook-dispatcher"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
+CONNECT_COMPONENT_NAME="playbook-dispatcher-connect"
 IMAGE="quay.io/cloudservices/playbook-dispatcher"
 IQE_CJI_TIMEOUT="30m"
 REF_ENV="insights-stage"
@@ -46,7 +47,7 @@ bonfire deploy playbook-dispatcher cloud-connector \
     --set-template-ref ${COMPONENT_NAME}=${GIT_COMMIT} \
     --set-image-tag ${IMAGE_DISPATCHER}=${IMAGE_TAG} \
     --set-image-tag ${IMAGE_CONNECT}=${IMAGE_TAG} \
-    --set-template-ref ${IMAGE_CONNECT}=047e256da507f29d0e0ae803a4b1d688eb74a2cb \
+    --set-template-ref ${CONNECT_COMPONENT_NAME}=047e256da507f29d0e0ae803a4b1d688eb74a2cb \
     --namespace ${NAMESPACE} \
     --timeout ${DEPLOY_TIMEOUT} \
     --set-parameter playbook-dispatcher/CLOUD_CONNECTOR_IMPL=impl


### PR DESCRIPTION
Lock the connect image to the template from before the managed kafka
params were put in place. This should let the connect image connect to
kafka in ephemeral when running tests

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Explain what the change is linking any relevant JIRAs or Issues.

Lock the connect image to a specific ref in ephemeral.

## Why?
Consider what business or engineering goal does this PR achieves.

This ref contains the connect.yaml from before we put all the managed kafka params 

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

Add the commit ref into the pr_check.sh

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
