### PR TITLE
Handle unexpected HTTPResponse in GetConnectionStatus

### DIFF
--- a/internal/api/connectors/cloudConnector.go
+++ b/internal/api/connectors/cloudConnector.go
@@ -154,5 +154,9 @@ func (this *cloudConnectorClientImpl) GetConnectionStatus(
 		return "", err
 	}
 
+	if res.JSON200 == nil {
+		return "", utils.UnexpectedResponse(res.HTTPResponse)
+	}
+
 	return *res.JSON200.Status, nil
 }


### PR DESCRIPTION
## What?
Handle non 200 response from cloud-connector in `GetConnectionStatus`

## Why?
Avoid panicking when trying to return the `JSON200.Status`

## How?
Uses `utils.UnexpectedResponse`, similar to other areas in the code.

## Testing

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
