### PR TITLE
Update README & Onboarding doc with stdout note

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ More examples:
 
 Default and available fields for each resource can be found in the [API schema](https://github.com/RedHatInsights/playbook-dispatcher/blob/master/schema/public.openapi.yaml)
 
+**Note:** Users interested in the up to date output of running playbooks should include the `stdout` field
+in their requests to the `/v1/run_hosts` endpoint.
+For example:
+
+- `/api/playbook-dispatcher/v1/run_hosts?fields[data]=host,status,stdout`
+
 ### Authentication
 
 The API is placed behind a [web gateway (3scale)](https://internal.cloud.redhat.com/docs/services/3scale/).

--- a/docs/onboarding/Onboarding.md
+++ b/docs/onboarding/Onboarding.md
@@ -100,6 +100,11 @@ Please refer to the following schema definitions for the details:
 * Public API endpoint to fetch playbook run information: [here](https://github.com/RedHatInsights/playbook-dispatcher/blob/master/schema/public.openapi.yaml#L17).
 * Public API endpoint to fetch host information: [here](https://github.com/RedHatInsights/playbook-dispatcher/blob/master/schema/public.openapi.yaml#L44).
 
+**Note:** Users interested in the up to date console output of currently running playbooks should include the `stdout` field in their requests to the endpoint that fetches host information (`/v1/run_hosts`).
+For example:
+
+- `/api/playbook-dispatcher/v1/run_hosts?fields[data]=host,status,stdout`
+
 ## Helpful Tips
 
 ### Dispatching multiple satellite playbook runs


### PR DESCRIPTION
## What?
Update Playbook Dispatcher Docs with explicit notes about retrieving playbook stdout.

## Why?
Based on a recent meeting with the Edge Management team it was made clear that the documentation around retrieving playbook stdout could be made more clear in our documentation.

## How?
Updated README and Onboarding.md with explicit notes on retrieving stdout info

## Testing

## Anything Else? 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
