### PR TITLE
Update cdappconfig to use public port

### DIFF
--- a/cdappconfig-sasl.json
+++ b/cdappconfig-sasl.json
@@ -1,5 +1,5 @@
 {
-    "webPort": 8000,
+    "publicPort": 8000,
     "metricsPort": 9001,
     "metricsPath": "/metrics",
     "logging": {

--- a/cdappconfig.json
+++ b/cdappconfig.json
@@ -1,6 +1,6 @@
 {
     "webPort": 8000,
-    "metricsPort": 9001,
+    "publicPort": 9001,
     "metricsPath": "/metrics",
     "logging": {
         "type": "cloudwatch",

--- a/cdappconfig.json
+++ b/cdappconfig.json
@@ -1,6 +1,6 @@
 {
-    "webPort": 8000,
-    "publicPort": 9001,
+    "publicPort": 8000,
+    "metricsPort": 9001,
     "metricsPath": "/metrics",
     "logging": {
         "type": "cloudwatch",


### PR DESCRIPTION
## What?
Update cdappconfig.json to use public port instead of webPort

## Why?
Web port has been deprecated by app-interface.

## How?
Update the fields to be the correct value.

## Testing
None!

## Anything Else?

## Secure Coding Practices Checklist Link

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
