### PR TITLE
Updating dispatcher connect amq-streams image to kafka-30

### DIFF
--- a/event-streams/Dockerfile
+++ b/event-streams/Dockerfile
@@ -24,7 +24,7 @@ RUN ./mvnw -Dschema.event.run=/src/run.event.yaml clean package && \
 
 
 # https://access.redhat.com/documentation/en-us/red_hat_amq/2021.q3/html-single/deploying_and_upgrading_amq_streams_on_openshift/index#creating-new-image-from-base-str
-FROM registry.redhat.io/amq7/amq-streams-kafka-30-rhel8:2.1.0
+FROM registry.redhat.io/amq7/amq-streams-kafka-31-rhel8:2.2.0
 
 ARG BUILD_COMMIT=unknown
 


### PR DESCRIPTION
## What?
This updates the `amq-streams` image used by dispatcher connect from `kafka-30` to `kafka-31`.

## Why?
`amq7/amq-streams-kafka-30-rhel8` is not available on the catalog.redhat.com anymore. We are currently using kafka 3.1.0 right now in all environments, so we should align with that here as well.

## How?
updated event-streams Dockerfile

## Testing
* test image created in quay
* used test image to deploy on `ephemeral-bjjhed`

## Anything Else?
[AMQ Streams Kafka - 3.1 Image Info](https://catalog.redhat.com/software/containers/amq7/amq-streams-kafka-31-rhel8/6254231f9c2e1a8a1e2ed869?container-tabs=overview)

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
