### PR TITLE
Disable minimum 3 replicas requirement for playbook-dispatcher-connect

### DIFF
--- a/deploy/connect.yaml
+++ b/deploy/connect.yaml
@@ -181,6 +181,7 @@ objects:
       app: playbook-dispatcher
     annotations:
       strimzi.io/use-connector-resources: "true"
+      ignore-check.kube-linter.io/minimum-three-replicas: "This deployment uses 1 pod, using more than 1 pod will produce more than 1 kafka messages for every db update"
   spec:
     image: ${KAFKA_CONNECT_IMAGE}:${IMAGE_TAG}
     version: ${VERSION}


### PR DESCRIPTION
## What?
Disables the minimum 3 replicas requirement for dispatcher connect.

## Why?
Using more than 1 replica for dispatcher connect will produce more than 1 kafka message for each db update.

## How?
Added the `ignore-check.kube-linter.io/minimum-three-replicas` annotation for the connect pod.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
