### PR TITLE
Add annotation so that min pod limit is ignored for the event-consumer which is only used in stage

### DIFF
--- a/deploy/connect.yaml
+++ b/deploy/connect.yaml
@@ -316,6 +316,8 @@ objects:
     labels:
       app: playbook-dispatcher
     name: playbook-dispatcher-event-consumer
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas: "This deployment uses 1 pod, using more than 1 pod will produce more than 1 kafka messages for every db update"
   spec:
     replicas: ${{EVENT_CONSUMER_REPLICAS}}
     selector:


### PR DESCRIPTION
## What?
Add annotation so that min pod limit is ignored for the event-consumer which is only used in stage

## Why?
app-interface is complaining that the event-consumer deployment only has 1 replica in stage...ignore that
