### PR TITLE
Remove the managed kafka authentication settings

### DIFF
--- a/deploy/connect.yaml
+++ b/deploy/connect.yaml
@@ -207,15 +207,6 @@ objects:
       offset.storage.replication.factor: ${KAFKA_REPLICATION_FACTOR}
       status.storage.replication.factor: ${KAFKA_REPLICATION_FACTOR}
       config.storage.replication.factor: ${KAFKA_REPLICATION_FACTOR}
-    tls:
-      trustedCertificates: []
-    authentication:
-      # this config is specific to PLAIN sasl mechanism
-      type: ${KAFKA_SASL_MECHANISM}
-      username: ${KAFKA_USERNAME}
-      passwordSecret:
-        secretName: clowder-auth
-        password: password 
     externalConfiguration:
       volumes:
         - name: rds-client-ca


### PR DESCRIPTION
## What?
Stage is no longer using managed kafka. 
Remove the managed kafka authentication settings from the playbook-dispatcher-connect deployment
