### PR TITLE
[RHCLOUD-29619] Use rhc_not_configured to comply with OpenAPI spec

### DIFF
--- a/internal/api/controllers/private/highlevelConnectionStatus.go
+++ b/internal/api/controllers/private/highlevelConnectionStatus.go
@@ -238,7 +238,7 @@ func getRHCStatus(hostDetails []inventory.HostDetails, orgID OrgId) RecipientWit
 		hostIDs[i] = host.ID
 	}
 
-	return formatConnectionResponse(nil, nil, nil, orgID, hostIDs, "none", "no_rhc")
+	return formatConnectionResponse(nil, nil, nil, orgID, hostIDs, "none", "rhc_not_configured")
 }
 
 func concatResponses(satellite []RecipientWithConnectionInfo, directConnect []RecipientWithConnectionInfo, noRHC []RecipientWithConnectionInfo) []RecipientWithConnectionInfo {


### PR DESCRIPTION
## What?
[RHCLOUD-29619](https://issues.redhat.com/browse/RHCLOUD-29619)

Playbook Dispatcher's high level API route's /internal/v2/connection_status endpoint is sending out invalid value for the status key.

The OpenAPI spec mentions that the "status" field under this endpoint is an enum with the following fields: connected, disconnected and rhc_not_configured.

However, in reality, Playbook Dispatcher is sending out no_rhc instead of rhc_not_configured.

## Why?
:bug: 

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
