### PR TITLE
Remove extra query parameter name when calling sources using the generated code

### DIFF
--- a/internal/api/connectors/sources/impl.go
+++ b/internal/api/connectors/sources/impl.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"playbook-dispatcher/internal/common/constants"
 	"playbook-dispatcher/internal/common/utils"
+	"strings"
 	"time"
 
 	"github.com/redhatinsights/platform-go-middlewares/request_id"

--- a/internal/api/connectors/sources/impl.go
+++ b/internal/api/connectors/sources/impl.go
@@ -48,6 +48,8 @@ func NewSourcesClientWithHttpRequestDoer(cfg *viper.Viper, doer HttpRequestDoer)
 					req.URL = newUrl
 				}
 
+				fmt.Println("sources url:", req.URL)
+
 				return nil
 			},
 		},

--- a/internal/api/connectors/sources/impl.go
+++ b/internal/api/connectors/sources/impl.go
@@ -33,6 +33,19 @@ func NewSourcesClientWithHttpRequestDoer(cfg *viper.Viper, doer HttpRequestDoer)
 					req.Header.Set(constants.HeaderIdentity, identity)
 				}
 
+				originalUrl := req.URL.String()
+				if strings.Contains(originalUrl, "filter=filter[") {
+					// Remove the extra filter parameter name
+					correctedUrl := strings.Replace(req.URL.String(), "filter=", "", -1)
+
+					newUrl, err := url.Parse(correctedUrl)
+					if err != nil {
+						return err
+					}
+
+					req.URL = newUrl
+				}
+
 				return nil
 			},
 		},


### PR DESCRIPTION
The generated code adds an extra "filter=" when building out the url:
```
>>> urllib.parse.unquote("/api/sources/v3.1/sources?filter=filter%5Bsource_ref%5D%5Beq%5D%3D6c8b50a7-15ec-4278-baf5-6838bf5631c4")
'/api/sources/v3.1/sources?filter=filter[source_ref][eq]=6c8b50a7-15ec-4278-baf5-6838bf5631c4'
```

Sources expects the url to look like the following:
```
>>> urllib.parse.unquote("/api/sources/v3.1/sources?filter%5Bsource_ref%5D%5Beq%5D=6c8b50a7-15ec-4278-baf5-6838bf5631c4")
'/api/sources/v3.1/sources?filter[source_ref][eq]=6c8b50a7-15ec-4278-baf5-6838bf5631c4'
>>>
```

This is pretty gross.  I feel bad about it.  This needs some tests wrapped around it.  That would make me feel a bit better about it.