### PR TITLE
Check for nil pointer in the sources client

### DIFF
--- a/internal/api/connectors/sources/impl.go
+++ b/internal/api/connectors/sources/impl.go
@@ -134,12 +134,20 @@ func (this *sourcesClientImpl) GetSourceConnectionDetails(ctx context.Context, s
 		return SourceConnectionStatus{}, err
 	}
 
+	if sourcesResponse == nil {
+		return SourceConnectionStatus{}, fmt.Errorf("GetSources returned an empty response")
+	}
+
 	source := (*sourcesResponse)[0]
 
 	rhcConnectionResponse, err := this.getRHCConnectionStatus(ctx, string(*source.Id))
 
 	if err != nil {
 		return SourceConnectionStatus{}, err
+	}
+
+	if rhcConnectionResponse == nil || rhcConnectionResponse.Data == nil {
+		return SourceConnectionStatus{}, fmt.Errorf("GetRHCConnectionStatus returned an empty response")
 	}
 
 	rhcInfo := (*rhcConnectionResponse).Data

--- a/internal/api/connectors/sources/sources_test.go
+++ b/internal/api/connectors/sources/sources_test.go
@@ -86,6 +86,36 @@ var _ = Describe("Sources", func() {
 			Expect(err.Error()).To(ContainSubstring("GetSources returned an empty response"))
 		})
 
+		It("interperates response correctly if getSources returns a response where an entry does not have an id", func() {
+			responses := []test.MockHttpResponse{
+				{StatusCode: 200, Body: `{"data": [{"name": "test", "availability_status": "connected"}]}`},
+				{StatusCode: 200, Body: `{}`},
+			}
+
+			doer := test.MockMultiResponseHttpClient(responses...)
+			client := NewSourcesClientWithHttpRequestDoer(config.Get(), doer)
+			ctx := test.TestContext()
+
+			_, err := client.GetSourceConnectionDetails(ctx, "4f37c752-ba1c-48b1-bcf7-4ef8f585d9ee")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("GetSources did not return a valid sources id"))
+		})
+
+		It("interperates response correctly if getSources returns a response where the data array is empty", func() {
+			responses := []test.MockHttpResponse{
+				{StatusCode: 200, Body: `{"data": []}`},
+				{StatusCode: 200, Body: `{}`},
+			}
+
+			doer := test.MockMultiResponseHttpClient(responses...)
+			client := NewSourcesClientWithHttpRequestDoer(config.Get(), doer)
+			ctx := test.TestContext()
+
+			_, err := client.GetSourceConnectionDetails(ctx, "4f37c752-ba1c-48b1-bcf7-4ef8f585d9ee")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("GetSources returned an empty response"))
+		})
+
 		It("interperates response correctly if getRhcConnectionStatus returns a 404", func() {
 			responses := []test.MockHttpResponse{
 				{StatusCode: 200, Body: `{"data": [{"id": "1", "name": "test", "availability_status": "connected"}]}`},

--- a/internal/api/connectors/sources/sources_test.go
+++ b/internal/api/connectors/sources/sources_test.go
@@ -71,6 +71,21 @@ var _ = Describe("Sources", func() {
 			Expect(err.Error()).To(ContainSubstring("Source Bad Request"))
 		})
 
+		It("interperates response correctly if getSources returns an empty response", func() {
+			responses := []test.MockHttpResponse{
+				{StatusCode: 200, Body: `{}`},
+				{StatusCode: 200, Body: `{}`},
+			}
+
+			doer := test.MockMultiResponseHttpClient(responses...)
+			client := NewSourcesClientWithHttpRequestDoer(config.Get(), doer)
+			ctx := test.TestContext()
+
+			_, err := client.GetSourceConnectionDetails(ctx, "4f37c752-ba1c-48b1-bcf7-4ef8f585d9ee")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("GetSources returned an empty response"))
+		})
+
 		It("interperates response correctly if getRhcConnectionStatus returns a 404", func() {
 			responses := []test.MockHttpResponse{
 				{StatusCode: 200, Body: `{"data": [{"id": "1", "name": "test", "availability_status": "connected"}]}`},
@@ -100,5 +115,21 @@ var _ = Describe("Sources", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("RHCStatus Bad Request"))
 		})
+
+		It("interperates response correctly if getRhcConnectionStatus returns an empty response", func() {
+			responses := []test.MockHttpResponse{
+				{StatusCode: 200, Body: `{"data": [{"id": "1", "name": "test", "availability_status": "connected"}]}`},
+				{StatusCode: 200, Body: `{}`},
+			}
+
+			doer := test.MockMultiResponseHttpClient(responses...)
+			client := NewSourcesClientWithHttpRequestDoer(config.Get(), doer)
+			ctx := test.TestContext()
+
+			_, err := client.GetSourceConnectionDetails(ctx, "4f37c752-ba1c-48b1-bcf7-4ef8f585d9ee")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("GetRHCConnectionStatus returned an empty response"))
+		})
+
 	})
 })


### PR DESCRIPTION
## What?
Its possible that the generated sources client can return a nil error and a nil pointer to the data.  When this happens, the code attempts to dereferrence the nil pointer...which causes a panic.  The web framework handles the panic and returns a 500 error.

RHCLOUD-31105

## Why?
Consider what business or engineering goal does this PR achieves.

## How?
Added more checks for nil pointers.

## Testing
More tests were added to the sources client.  

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
