### PR TITLE
Add an index on org_id, service and created_at to the runs table

### DIFF
--- a/migrations/015_add-index-labels-playbook-run.down.sql
+++ b/migrations/015_add-index-labels-playbook-run.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX runs_org_id_service_created_at_desc_index;

--- a/migrations/015_add-index-labels-playbook-run.up.sql
+++ b/migrations/015_add-index-labels-playbook-run.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX runs_org_id_service_created_at_desc_index ON runs (org_id, service, created_at DESC);


### PR DESCRIPTION
- [ ] research `concurrently` on the create index 
- [ ] test with more data


insights=# explain analyse select "id","labels",case when runs.status='running' and runs.created_at + runs.timeout * interval '1 second' <= now() then 'timeout' else runs.status end as status,"service","created_at","updated_at","url" from "runs" where (org_id = '5318290') and service in ('remediations','config_manager','test') and runs.service = 'remediations' and runs.labels ->> 'playbook-run' = '7978185d-88c8-47f3-8273-bbeaf67d67c9' order by created_at desc,id limit 50;
                                                                                                                                QUERY PLAN                                                     
                                                                            
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
----------------------------------------------------------------------------
 Limit  (cost=541.52..541.53 rows=1 width=93) (actual time=1.140..1.141 rows=0 loops=1)
   ->  Sort  (cost=541.52..541.53 rows=1 width=93) (actual time=1.139..1.140 rows=0 loops=1)
         Sort Key: created_at DESC, id
         Sort Method: quicksort  Memory: 25kB
         ->  Seq Scan on runs  (cost=0.00..541.51 rows=1 width=93) (actual time=1.135..1.136 rows=0 loops=1)
               Filter: (((org_id)::text = '5318290'::text) AND ((service)::text = 'remediations'::text) AND ((service)::text = ANY ('{remediations,config_manager,test}'::text[])) AND ((labels
 ->> 'playbook-run'::text) = '7978185d-88c8-47f3-8273-bbeaf67d67c9'::text))
               Rows Removed by Filter: 10000
 Planning Time: 0.088 ms
 Execution Time: 1.156 ms
(9 rows)


----
Run migrations that apply index
----


insights=# explain analyse select "id","labels",case when runs.status='running' and runs.created_at + runs.timeout * interval '1 second' <= now() then 'timeout' else runs.status end as status,"service","created_at","updated_at","url" from "runs" where (org_id = '5318290') and service in ('remediations','config_manager','test') and runs.service = 'remediations' and runs.labels ->> 'playbook-run' = '7978185d-88c8-47f3-8273-bbeaf67d67c9' order by created_at desc,id limit 50;
                                                                         QUERY PLAN                                                                          
-------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=6.09..6.09 rows=1 width=93) (actual time=0.013..0.013 rows=0 loops=1)
   ->  Sort  (cost=6.09..6.09 rows=1 width=93) (actual time=0.012..0.012 rows=0 loops=1)
         Sort Key: created_at DESC, id
         Sort Method: quicksort  Memory: 25kB
         ->  Index Scan using runs_org_id_service_created_at_desc_index on runs  (cost=0.29..6.08 rows=1 width=93) (actual time=0.009..0.009 rows=0 loops=1)
               Index Cond: (((org_id)::text = '5318290'::text) AND ((service)::text = 'remediations'::text))
               Filter: ((labels ->> 'playbook-run'::text) = '7978185d-88c8-47f3-8273-bbeaf67d67c9'::text)
 Planning Time: 0.140 ms
 Execution Time: 0.024 ms
(9 rows)
