### PR TITLE
Adding an index on org_id, correlation_id and status on runs

### DIFF
--- a/migrations/016_add-index-labels-playbook-run.down.sql
+++ b/migrations/016_add-index-labels-playbook-run.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX runs_org_id_correlation_id_status_index;

--- a/migrations/016_add-index-labels-playbook-run.up.sql
+++ b/migrations/016_add-index-labels-playbook-run.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX runs_org_id_correlation_id_status_index ON runs (org_id, correlation_id, status);


### PR DESCRIPTION
- [ ] research `concurrently` on the create index 
- [ ] test with more data

```
insights=# EXPLAIN ANALYZE UPDATE runs SET status='running', events='{}', updated_at=NOW() WHERE (org_id = '5318290') AND (correlation_id = '7978185d-88c8-47f3-8273-bbeaf67d67c9') AND status not in ('success','failure');
                                                                                    QUERY PLAN                                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Update on runs  (cost=0.00..479.00 rows=1 width=286) (actual time=1.225..1.225 rows=0 loops=1)
   ->  Seq Scan on runs  (cost=0.00..479.00 rows=1 width=286) (actual time=1.224..1.224 rows=0 loops=1)
         Filter: ((status <> ALL ('{success,failure}'::runs_status[])) AND ((org_id)::text = '5318290'::text) AND (correlation_id = '7978185d-88c8-47f3-8273-bbeaf67d67c9'::uuid))
         Rows Removed by Filter: 10000
 Planning Time: 0.099 ms
 Execution Time: 1.251 ms
(6 rows)

insights=# create index idx_new_index on runs (org_id, correlation_id, status);
CREATE INDEX
insights=# EXPLAIN ANALYZE UPDATE runs SET status='running', events='{}', updated_at=NOW() WHERE (org_id = '5318290') AND (correlation_id = '7978185d-88c8-47f3-8273-bbeaf67d67c9') AND status not in ('success','failure');
                                                          QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
 Update on runs  (cost=0.29..8.31 rows=1 width=286) (actual time=0.009..0.009 rows=0 loops=1)
   ->  Index Scan using idx_new_index on runs  (cost=0.29..8.31 rows=1 width=286) (actual time=0.009..0.009 rows=0 loops=1)
         Index Cond: (((org_id)::text = '5318290'::text) AND (correlation_id = '7978185d-88c8-47f3-8273-bbeaf67d67c9'::uuid))
         Filter: (status <> ALL ('{success,failure}'::runs_status[]))
 Planning Time: 0.130 ms
 Execution Time: 0.025 ms
(6 rows)

```
