### PR TITLE
Change jsonb search operator so hopefully the existing index will get used

### DIFF
--- a/internal/api/controllers/public/runHostsList.go
+++ b/internal/api/controllers/public/runHostsList.go
@@ -61,7 +61,8 @@ func (this *controllers) ApiRunHostsList(ctx echo.Context, params ApiRunHostsLis
 		}
 
 		if labelFilters := middleware.GetDeepObject(ctx, "filter", "run", "labels"); len(labelFilters) > 0 {
-			queryBuilder = convertLabelFilterToLabelWhereClause(queryBuilder, labelFilters)
+			queryBuilder, _ = addLabelFilterToQueryAsWhereClause(queryBuilder, labelFilters)
+			// FIXME:  Don't eat the error!
 		}
 
 		if params.Filter.InventoryId != nil {

--- a/internal/api/controllers/public/runHostsList.go
+++ b/internal/api/controllers/public/runHostsList.go
@@ -61,11 +61,7 @@ func (this *controllers) ApiRunHostsList(ctx echo.Context, params ApiRunHostsLis
 		}
 
 		if labelFilters := middleware.GetDeepObject(ctx, "filter", "run", "labels"); len(labelFilters) > 0 {
-			for key, values := range labelFilters {
-				for _, value := range values {
-					queryBuilder.Where("runs.labels ->> ? = ?", key, value)
-				}
-			}
+			queryBuilder = convertLabelFilterToLabelWhereClause(queryBuilder, labelFilters)
 		}
 
 		if params.Filter.InventoryId != nil {

--- a/internal/api/controllers/public/runHostsList.go
+++ b/internal/api/controllers/public/runHostsList.go
@@ -61,8 +61,11 @@ func (this *controllers) ApiRunHostsList(ctx echo.Context, params ApiRunHostsLis
 		}
 
 		if labelFilters := middleware.GetDeepObject(ctx, "filter", "run", "labels"); len(labelFilters) > 0 {
-			queryBuilder, _ = addLabelFilterToQueryAsWhereClause(queryBuilder, labelFilters)
-			// FIXME:  Don't eat the error!
+			queryBuilder, err = addLabelFilterToQueryAsWhereClause(queryBuilder, labelFilters)
+			if err != nil {
+				instrumentation.PlaybookApiRequestError(ctx, err)
+				return echo.NewHTTPError(http.StatusInternalServerError, "Unable to handle labels query!")
+			}
 		}
 
 		if params.Filter.InventoryId != nil {

--- a/internal/api/instrumentation/probes.go
+++ b/internal/api/instrumentation/probes.go
@@ -109,6 +109,10 @@ func PlaybookRunHostCreateError(ctx context.Context, err error, data []dbModel.R
 	errorTotal.WithLabelValues(labelDb, labelPlaybookRunHostCreate, requestType, api.GetApiVersion(ctx)).Inc()
 }
 
+func PlaybookApiRequestError(ctx echo.Context, err error) {
+	utils.GetLogFromEcho(ctx).Errorw("Unable to process api request", "error", err)
+}
+
 func PlaybookRunCancelError(ctx context.Context, err error) {
 	utils.GetLogFromContext(ctx).Errorw("Error canceling run", "error", err)
 	runCanceledErrorTotal.Inc()


### PR DESCRIPTION
This PR changes the jsonb search operator that is used for searching/matching within the `labels` column.  Change from the `->>` operator to the `@>` operator allows the db to use the existing index on the `labels` column.

->> operator

```
                                                                                                                                    QUERY PLAN                                                                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=373161.62..373165.12 rows=30 width=256) (actual time=2059.191..2059.268 rows=1 loops=1)
   ->  Gather Merge  (cost=373161.62..373165.12 rows=30 width=256) (actual time=2059.189..2059.266 rows=1 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Sort  (cost=372161.60..372161.64 rows=15 width=256) (actual time=2044.570..2044.571 rows=0 loops=3)
               Sort Key: created_at DESC, id
               Sort Method: quicksort  Memory: 25kB
               Worker 0:  Sort Method: quicksort  Memory: 25kB
               Worker 1:  Sort Method: quicksort  Memory: 25kB
               ->  Parallel Seq Scan on runs  (cost=0.00..372161.31 rows=15 width=256) (actual time=1721.918..2044.514 rows=0 loops=3)
                     Filter: (((org_id)::text = '11789772'::text) AND ((service)::text = 'remediations'::text) AND ((service)::text = ANY ('{remediations,config_manager,test}'::text[])) AND ((labels ->> 'playbook-run'::text) = '7978185d-88c8-47f3-8273-bbeaf67d67c9'::text))
                     Rows Removed by Filter: 1141134
 Planning Time: 0.722 ms
 Execution Time: 2059.337 ms
(14 rows)

                                                                                                                                    QUERY PLAN                                                                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Finalize Aggregate  (cost=373161.34..373161.35 rows=1 width=8) (actual time=1104.062..1105.402 rows=1 loops=1)
   ->  Gather  (cost=373161.12..373161.33 rows=2 width=8) (actual time=1104.051..1105.395 rows=3 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Partial Aggregate  (cost=372161.12..372161.13 rows=1 width=8) (actual time=1094.317..1094.318 rows=1 loops=3)
               ->  Parallel Seq Scan on runs  (cost=0.00..372161.08 rows=15 width=0) (actual time=921.903..1094.314 rows=0 loops=3)
                     Filter: (((org_id)::text = '11789772'::text) AND ((service)::text = 'remediations'::text) AND ((service)::text = ANY ('{remediations,config_manager,test}'::text[])) AND ((labels ->> 'playbook-run'::text) = '7978185d-88c8-47f3-8273-bbeaf67d67c9'::text))
                     Rows Removed by Filter: 1141134
 Planning Time: 0.146 ms
 Execution Time: 1105.448 ms
(10 rows)
```

@> operator

```
                                                                                     QUERY PLAN                                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=13085.38..13085.40 rows=7 width=256) (actual time=29.249..29.251 rows=1 loops=1)
   ->  Sort  (cost=13085.38..13085.40 rows=7 width=256) (actual time=29.248..29.249 rows=1 loops=1)
         Sort Key: created_at DESC, id
         Sort Method: quicksort  Memory: 25kB
         ->  Bitmap Heap Scan on runs  (cost=381.74..13085.29 rows=7 width=256) (actual time=29.242..29.243 rows=1 loops=1)
               Recheck Cond: (labels @> '{"playbook-run": "7978185d-88c8-47f3-8273-bbeaf67d67c9"}'::jsonb)
               Filter: (((org_id)::text = '11789772'::text) AND ((service)::text = 'remediations'::text) AND ((service)::text = ANY ('{remediations,config_manager,test}'::text[])))
               Heap Blocks: exact=1
               ->  Bitmap Index Scan on runs_labels_index  (cost=0.00..381.74 rows=3432 width=0) (actual time=29.231..29.232 rows=2 loops=1)
                     Index Cond: (labels @> '{"playbook-run": "7978185d-88c8-47f3-8273-bbeaf67d67c9"}'::jsonb)
 Planning Time: 2.387 ms
 Execution Time: 29.279 ms
(12 rows)

                                                                                  QUERY PLAN                                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=13085.20..13085.21 rows=1 width=8) (actual time=1.157..1.158 rows=1 loops=1)
   ->  Bitmap Heap Scan on runs  (cost=381.74..13085.18 rows=7 width=0) (actual time=1.155..1.155 rows=1 loops=1)
         Recheck Cond: (labels @> '{"playbook-run": "7978185d-88c8-47f3-8273-bbeaf67d67c9"}'::jsonb)
         Filter: (((org_id)::text = '11789772'::text) AND ((service)::text = 'remediations'::text) AND ((service)::text = ANY ('{remediations,config_manager,test}'::text[])))
         Heap Blocks: exact=1
         ->  Bitmap Index Scan on runs_labels_index  (cost=0.00..381.74 rows=3432 width=0) (actual time=1.148..1.148 rows=2 loops=1)
               Index Cond: (labels @> '{"playbook-run": "7978185d-88c8-47f3-8273-bbeaf67d67c9"}'::jsonb)
 Planning Time: 0.072 ms
 Execution Time: 1.178 ms
(9 rows)

```


Local testing results


Test url:
```
"http://localhost:8000/api/playbook-dispatcher/v1/runs?filter[labels][playbook-run]=294d4b2c-4475-42f6-b817-5b394332fe26" 
```


Data in local database:

```
insights=# select count(1) from runs;
 count  
--------
 868313
(1 row)
```

Testing existing approach

```
git checkout master

make run
```


Test run #1 (notice "time" field):

```
{"level":"debug","ts":1709043215.153447,"caller":"db/db.go:86","msg":"executed query","request_id":"1234","sql":"SELECT count(1) FROM \"runs\" WHERE (org_id = '5318290') AND service IN ('remediations','config_manager','test') AND runs.labels ->> 'playbook-run' = '294d4b2c-4475-42f6-b817-5b394332fe26'","rows":1,"elapsed":74}
{"level":"debug","ts":1709043215.2238152,"caller":"db/db.go:86","msg":"executed query","request_id":"1234","sql":"SELECT \"id\",\"org_id\",\"recipient\",\"url\",\"labels\",\"timeout\",CASE WHEN runs.status='running' AND runs.created_at + runs.timeout * interval '1 second' <= NOW() THEN 'timeout' ELSE runs.status END as status FROM \"runs\" WHERE (org_id = '5318290') AND service IN ('remediations','config_manager','test') AND runs.labels ->> 'playbook-run' = '294d4b2c-4475-42f6-b817-5b394332fe26' ORDER BY created_at desc,id LIMIT 50","rows":1,"elapsed":70}
{"level":"info","ts":1709043215.2239504,"caller":"middleware/logger.go:35","msg":"request completed","request_id":"1234","account":"111000","org_id":"5318290","time":"145.399992ms","status":200,"method":"GET","url":"/api/playbook-dispatcher/v1/runs?filter[labels][playbook-run]=294d4b2c-4475-42f6-b817-5b394332fe26","referer":"","user_agent":"curl/7.82.0"}
```


Test run #2 (notice "time" field):

```
{"level":"debug","ts":1709043240.1485152,"caller":"db/db.go:86","msg":"executed query","request_id":"1234","sql":"SELECT count(1) FROM \"runs\" WHERE (org_id = '5318290') AND service IN ('remediations','config_manager','test') AND runs.labels ->> 'playbook-run' = '294d4b2c-4475-42f6-b817-5b394332fe26'","rows":1,"elapsed":74}
{"level":"debug","ts":1709043240.220025,"caller":"db/db.go:86","msg":"executed query","request_id":"1234","sql":"SELECT \"id\",\"org_id\",\"recipient\",\"url\",\"labels\",\"timeout\",CASE WHEN runs.status='running' AND runs.created_at + runs.timeout * interval '1 second' <= NOW() THEN 'timeout' ELSE runs.status END as status FROM \"runs\" WHERE (org_id = '5318290') AND service IN ('remediations','config_manager','test') AND runs.labels ->> 'playbook-run' = '294d4b2c-4475-42f6-b817-5b394332fe26' ORDER BY created_at desc,id LIMIT 50","rows":1,"elapsed":71}
{"level":"info","ts":1709043240.2201035,"caller":"middleware/logger.go:35","msg":"request completed","request_id":"1234","account":"111000","org_id":"5318290","time":"145.930828ms","status":200,"method":"GET","url":"/api/playbook-dispatcher/v1/runs?filter[labels][playbook-run]=294d4b2c-4475-42f6-b817-5b394332fe26","referer":"","user_agent":"curl/7.82.0"}
```

Testing existing approach

```
git checkout change_jsonb_search_operator

make run
```


Test run #1 (notice "time" field):

```
{"level":"debug","ts":1709043297.4709234,"caller":"db/db.go:86","msg":"executed query","request_id":"1234","sql":"SELECT count(1) FROM \"runs\" WHERE (org_id = '5318290') AND service IN ('remediations','config_manager','test') AND runs.labels @> '{\"playbook-run\":\"294d4b2c-4475-42f6-b817-5b394332fe26\"}'","rows":1,"elapsed":3}
{"level":"debug","ts":1709043297.4735463,"caller":"db/db.go:86","msg":"executed query","request_id":"1234","sql":"SELECT \"id\",\"org_id\",\"recipient\",\"url\",\"labels\",\"timeout\",CASE WHEN runs.status='running' AND runs.created_at + runs.timeout * interval '1 second' <= NOW() THEN 'timeout' ELSE runs.status END as status FROM \"runs\" WHERE (org_id = '5318290') AND service IN ('remediations','config_manager','test') AND runs.labels @> '{\"playbook-run\":\"294d4b2c-4475-42f6-b817-5b394332fe26\"}' ORDER BY created_at desc,id LIMIT 50","rows":1,"elapsed":2}
{"level":"info","ts":1709043297.4736693,"caller":"middleware/logger.go:35","msg":"request completed","request_id":"1234","account":"111000","org_id":"5318290","time":"6.500008ms","status":200,"method":"GET","url":"/api/playbook-dispatcher/v1/runs?filter[labels][playbook-run]=294d4b2c-4475-42f6-b817-5b394332fe26","referer":"","user_agent":"curl/7.82.0"}
```


Test run #2 (notice "time" field):

```
{"level":"debug","ts":1709043341.9367018,"caller":"db/db.go:86","msg":"executed query","request_id":"1234","sql":"SELECT count(1) FROM \"runs\" WHERE (org_id = '5318290') AND service IN ('remediations','config_manager','test') AND runs.labels @> '{\"playbook-run\":\"294d4b2c-4475-42f6-b817-5b394332fe26\"}'","rows":1,"elapsed":1}
{"level":"debug","ts":1709043341.9381533,"caller":"db/db.go:86","msg":"executed query","request_id":"1234","sql":"SELECT \"id\",\"org_id\",\"recipient\",\"url\",\"labels\",\"timeout\",CASE WHEN runs.status='running' AND runs.created_at + runs.timeout * interval '1 second' <= NOW() THEN 'timeout' ELSE runs.status END as status FROM \"runs\" WHERE (org_id = '5318290') AND service IN ('remediations','config_manager','test') AND runs.labels @> '{\"playbook-run\":\"294d4b2c-4475-42f6-b817-5b394332fe26\"}' ORDER BY created_at desc,id LIMIT 50","rows":1,"elapsed":1}
{"level":"info","ts":1709043341.938212,"caller":"middleware/logger.go:35","msg":"request completed","request_id":"1234","account":"111000","org_id":"5318290","time":"3.528334ms","status":200,"method":"GET","url":"/api/playbook-dispatcher/v1/runs?filter[labels][playbook-run]=294d4b2c-4475-42f6-b817-5b394332fe26","referer":"","user_agent":"curl/7.82.0"}
```




