### PR TITLE
Check the response from the database query sooner in the response-consumer

### DIFF
--- a/internal/response-consumer/handler.go
+++ b/internal/response-consumer/handler.go
@@ -83,6 +83,15 @@ func (this *handler) onMessage(ctx context.Context, msg *k.Message) {
 
 		selectResult := baseQuery.Select("id", "status", "response_full").First(&run)
 
+		if selectResult.Error != nil {
+			if errors.Is(selectResult.Error, gorm.ErrRecordNotFound) {
+				return nil
+			}
+
+			utils.GetLogFromContext(ctx).Errorw("Error fetching run from db", "error", selectResult.Error)
+			return selectResult.Error
+		}
+
 		if requestType == satMessageHeaderValue {
 			satellite.SortSatEvents(value.SatEvents)
 
@@ -99,15 +108,6 @@ func (this *handler) onMessage(ctx context.Context, msg *k.Message) {
 		} else {
 			status = inferStatus(value.RunnerEvents, nil)
 			eventsSerialized = utils.MustMarshal(value.RunnerEvents)
-		}
-
-		if selectResult.Error != nil {
-			if errors.Is(selectResult.Error, gorm.ErrRecordNotFound) {
-				return nil
-			}
-
-			utils.GetLogFromContext(ctx).Errorw("Error fetching run from db", "error", selectResult.Error)
-			return selectResult.Error
 		}
 
 		toUpdate := db.Run{


### PR DESCRIPTION
This code seems to be using the `run` from the database query before we check for an error from the database.  This seems like a bug.