### PR TITLE
We retrieved the run id during the first query so lets pass it into the update statement to speed up the update

### DIFF
--- a/internal/response-consumer/handler.go
+++ b/internal/response-consumer/handler.go
@@ -115,6 +115,9 @@ func (this *handler) onMessage(ctx context.Context, msg *k.Message) {
 			Events: eventsSerialized,
 		}
 
+		// We retrieved the run id (primary key) above...lets use it here during the update to speed up the query
+		baseQuery = baseQuery.Where("id = ?", run.ID)
+
 		// Only update if the run is not marked as complete
 		updateResult := baseQuery.Where("status not in ?", []string{db.RunStatusSuccess, db.RunStatusFailure}).Select("status", "events").Updates(toUpdate)
 		if updateResult.Error != nil {


### PR DESCRIPTION
The queries in the response-consumer appear to be driving the load on the database up.

We retrieved the run id during the first query so lets pass it into the update statement to speed up the update.  This is step 1.  We likely need to add an index on org_id and correlation id to speed up the query that locates the run id.

Using this PR for its automated tests.  Does this break anything?  This change does not appear to break the tests.

Thinking:  this will not work if a single correlation_id is mapped to multiple runs, but I don't think that is the case.  :thinking: 

No, it looks like each new run is associated with a new correlation id.

A new correlation id is created for each new run:
https://github.com/RedHatInsights/playbook-dispatcher/blob/master/internal/api/dispatch/impl.go#L52

newRun():
https://github.com/RedHatInsights/playbook-dispatcher/blob/master/internal/api/dispatch/db.go#L11

RHCLOUD-31330