### PR TITLE
Revert "RHCLOUD-29056 Upgrade debezium to 2.5 (#356)"

### DIFF
--- a/deploy/connect-msk.yaml
+++ b/deploy/connect-msk.yaml
@@ -283,7 +283,7 @@ objects:
         slot.name: debezium
         plugin.name: pgoutput
         slot.max.retries: 999999999
-        topic.prefix: playbook-dispatcher
+        database.server.name: playbook-dispatcher
         table.include.list: public.runs,public.run_hosts
         tombstones.on.delete: false
 

--- a/deploy/connect.yaml
+++ b/deploy/connect.yaml
@@ -274,7 +274,7 @@ objects:
         slot.name: debezium
         plugin.name: pgoutput
         slot.max.retries: 999999999
-        topic.prefix: playbook-dispatcher
+        database.server.name: playbook-dispatcher
         table.include.list: public.runs,public.run_hosts
         tombstones.on.delete: false
 

--- a/event-streams/Dockerfile
+++ b/event-streams/Dockerfile
@@ -3,8 +3,8 @@ USER root
 
 ENV EXTRA_PLUGINS=/deps/plugins \
     EXTRA_LIBS=/deps/libs \
-    DEBEZIUM_VERSION=2.5.3.Final \
-    DEBEZIUM_CHECKSUM=0e119e8fac1a0bc0c35c009786110508 \
+    DEBEZIUM_VERSION=1.9.7.Final \
+    DEBEZIUM_CHECKSUM=161e362568163639fcde39da27e29456 \
     CONFIG_PROVIDERS_VERSION=0.1.0 \
     CONFIG_PROVIDERS_CHECKSUM=108e0bf4148a37676bed866ff45e1199
 
@@ -16,7 +16,7 @@ ADD schema/run.host.event.yaml /src
 RUN microdnf install gzip
 
 # Taken from https://github.com/debezium/docker-images/blob/master/connect-base/1.9/docker-maven-download.sh
-# Debezium PostgreSQL checksum from https://github.com/debezium/container-images/blob/main/connect/2.5/Dockerfile
+# Debezium PostgreSQL checksum from https://github.com/debezium/container-images/blob/main/connect/1.9/Dockerfile
 RUN mkdir -p $EXTRA_PLUGINS $EXTRA_LIBS && \
     MAVEN_DEP_DESTINATION=$EXTRA_PLUGINS /src/docker-maven-download.sh debezium postgres ${DEBEZIUM_VERSION} ${DEBEZIUM_CHECKSUM} && \
     MAVEN_DEP_DESTINATION=$EXTRA_LIBS /src/docker-maven-download.sh central com/redhat/insights/kafka config-providers ${CONFIG_PROVIDERS_VERSION} ${CONFIG_PROVIDERS_CHECKSUM}

--- a/event-streams/connector.json
+++ b/event-streams/connector.json
@@ -13,7 +13,7 @@
         "slot.name": "debezium",
         "plugin.name": "pgoutput",
         "slot.max.retries": 999999999,
-        "topic.prefix": "playbook-dispatcher",
+        "database.server.name": "playbook-dispatcher",
         "table.include.list": "public.runs,public.run_hosts",
         "tombstones.on.delete": false,
 

--- a/event-streams/docker-maven-download.sh
+++ b/event-streams/docker-maven-download.sh
@@ -84,25 +84,9 @@ maven_apicurio_converter() {
         return
     fi
     APICURIO_CONVERTER_PACKAGE="apicurio-registry-distro-connect-converter"
-    maven_dep $MAVEN_REPO_CENTRAL "io/apicurio" "$APICURIO_CONVERTER_PACKAGE" "$1" "$APICURIO_CONVERTER_PACKAGE-$1.tar.gz" "$2"
+    maven_dep $MAVEN_REPO_CENTRAL "io/apicurio" "$APICURIO_CONVERTER_PACKAGE" "$1" "$APICURIO_CONVERTER_PACKAGE-$1-converter.tar.gz" "$2"
     mkdir "$EXTERNAL_LIBS_DIR/apicurio"
     tar -xzf "$DOWNLOAD_FILE" -C "$EXTERNAL_LIBS_DIR/apicurio" && rm "$DOWNLOAD_FILE"
-}
-
-maven_otel_libs() {
-    if [[ -z "$EXTERNAL_LIBS_DIR" ]] ; then
-        echo "WARNING: EXTERNAL_LIBS_DIR is not set. Skipping loading OTEL libraries ..."
-        return
-    fi
-    if [[ ! -d "$EXTERNAL_LIBS_DIR" ]] ; then
-        echo "WARNING: EXTERNAL_LIBS_DIR is not a directory. Skipping loading OTEL libraries ..."
-        return
-    fi
-    if [[ ! -d "$EXTERNAL_LIBS_DIR/otel" ]] ; then
-	mkdir "$EXTERNAL_LIBS_DIR/otel"
-    fi
-    maven_dep $MAVEN_REPO_CENTRAL $1 $2 $3 "$2-$3.jar" $4
-    mv "$DOWNLOAD_FILE" $EXTERNAL_LIBS_DIR/otel
 }
 
 case $1 in
@@ -126,8 +110,5 @@ case $1 in
             ;;
     "apicurio" ) shift
             maven_apicurio_converter ${@}
-            ;;
-    "otel" ) shift
-            maven_otel_libs ${@}
             ;;
 esac

--- a/examples/connector-local.json
+++ b/examples/connector-local.json
@@ -13,7 +13,7 @@
         "slot.name": "debezium",
         "plugin.name": "pgoutput",
         "slot.max.retries": 999999999,
-        "topic.prefix": "playbook-dispatcher",
+        "database.server.name": "playbook-dispatcher",
         "table.include.list": "public.runs,public.run_hosts",
 
         "key.converter": "org.apache.kafka.connect.storage.StringConverter",


### PR DESCRIPTION
## What?
This reverts commit c710f42552b8f776590179a8b05d5446df3c6a7b.


## Why?
We are looking at some new WARNs and unsure if they are caused by these changes

2024-03-27 19:34:14,474 WARN [playbook-dispatcher-event-interface|task-0] [Producer clientId=connector-producer-playbook-dispatcher-event-interface-0] Error while fetching metadata with correlation id 184593 : {__debezium-heartbeat.playbook-dispatcher=UNKNOWN_TOPIC_OR_PARTITION} (org.apache.kafka.clients.NetworkClient) [kafka-producer-network-thread | connector-producer-playbook-dispatcher-event-interface-0]

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
