### PR TITLE
Use topic.heartbeat.prefix instead of the old heartbeat.topics.prefix

### DIFF
--- a/deploy/connect-msk.yaml
+++ b/deploy/connect-msk.yaml
@@ -305,7 +305,7 @@ objects:
         errors.log.include.messages: "true"
 
         heartbeat.interval.ms: 600000
-        heartbeat.topics.prefix: "__debezium-heartbeat-pd"
+        topic.heartbeat.prefix: "__debezium-heartbeat-pd"
         heartbeat.action.query: "INSERT INTO public.runs (id, org_id, recipient, correlation_id, url, service, timeout, created_at, updated_at) VALUES ('98875b33-b37e-4c35-be8b-d74f321bac28', '5318290', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 'https://redhat.com', 'heartbeat', 3600, NOW(), NOW()) ON CONFLICT(id) DO UPDATE SET updated_at=NOW();"
 
 - apiVersion: apps/v1

--- a/deploy/connect.yaml
+++ b/deploy/connect.yaml
@@ -298,7 +298,7 @@ objects:
         errors.log.include.messages: "true"
 
         heartbeat.interval.ms: 600000
-        heartbeat.topics.prefix: "__debezium-heartbeat-pd"
+        topic.heartbeat.prefix: "__debezium-heartbeat-pd"
         heartbeat.action.query: "INSERT INTO public.runs (id, org_id, recipient, correlation_id, url, service, timeout, created_at, updated_at) VALUES ('98875b33-b37e-4c35-be8b-d74f321bac28', '5318290', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 'https://redhat.com', 'heartbeat', 3600, NOW(), NOW()) ON CONFLICT(id) DO UPDATE SET updated_at=NOW();"
 
 - apiVersion: apps/v1

--- a/event-streams/connector.json
+++ b/event-streams/connector.json
@@ -37,7 +37,7 @@
         "errors.log.include.messages":true,
 
         "heartbeat.interval.ms": 600000,
-        "heartbeat.topics.prefix": "__debezium-heartbeat-pd",
+        "topic.heartbeat.prefix": "__debezium-heartbeat-pd",
         "heartbeat.action.query": "INSERT INTO public.runs (id, org_id, recipient, correlation_id, url, service, timeout, created_at, updated_at) VALUES ('98875b33-b37e-4c35-be8b-d74f321bac28', '5318290', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 'https://redhat.com', 'heartbeat', 3600, NOW(), NOW()) ON CONFLICT(id) DO UPDATE SET updated_at=NOW();"
     }
 }

--- a/examples/connector-local.json
+++ b/examples/connector-local.json
@@ -39,7 +39,7 @@
         "errors.log.include.messages":true,
 
         "heartbeat.interval.ms": 60000,
-        "heartbeat.topics.prefix": "__debezium-heartbeat-pd",
+        "topic.heartbeat.prefix": "__debezium-heartbeat-pd",
         "heartbeat.action.query": "INSERT INTO public.runs (id, org_id, recipient, correlation_id, url, service, timeout, created_at, updated_at) VALUES ('98875b33-b37e-4c35-be8b-d74f321bac28', '5318290', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 'https://redhat.com', 'heartbeat', 3600, NOW(), NOW()) ON CONFLICT(id) DO UPDATE SET updated_at=NOW();"
     }
 }


### PR DESCRIPTION
## What?
Should fix some errors we saw on stage where it complains about
 a topic.

Turns out we were using the wrong configuration value and the
 wrong topic.

## Why?
We saw errors in stage logs (Thanks @tahmidefaz !)

```
2024-03-27 19:34:14,474 WARN [playbook-dispatcher-event-interface|task-0] [Producer clientId=connector-producer-playbook-dispatcher-event-interface-0] Error while fetching metadata with correlation id 184593 : {__debezium-heartbeat.playbook-dispatcher=UNKNOWN_TOPIC_OR_PARTITION} (org.apache.kafka.clients.NetworkClient) [kafka-producer-network-thread | connector-producer-playbook-dispatcher-event-interface-0]
```

## How?
Compared the docs about 1.9 vs 2.5 version

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
