### PR TITLE
Add index for run id lookup in response-consumer

### DIFF
--- a/migrations/015_add_index-org-id_correlation-id_playbook-run.down.sql
+++ b/migrations/015_add_index-org-id_correlation-id_playbook-run.down.sql
@@ -1,1 +1,1 @@
-DROP INDEX runs_org_id_correlation_id_run_id_index;
+DROP INDEX CONCURRENTLY IF EXISTS runs_org_id_correlation_id_run_id_index;

--- a/migrations/015_add_index-org-id_correlation-id_playbook-run.down.sql
+++ b/migrations/015_add_index-org-id_correlation-id_playbook-run.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX runs_org_id_correlation_id_run_id_index;

--- a/migrations/015_add_index-org-id_correlation-id_playbook-run.up.sql
+++ b/migrations/015_add_index-org-id_correlation-id_playbook-run.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS runs_org_id_correlation_id_run_id_index ON runs (org_id, correlation_id, id);
+


### PR DESCRIPTION
```playbook-dispatcher=# explain analyze                                                                 
SELECT "id","status","response_full" FROM "runs" WHERE (org_id = '5318290') AND (correlation_id = '7978185d-88c8-47f3-8273-bbeaf67d67c9') ORDER BY "runs"."id" LIMIT 50

;
                                                           QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=51.57..51.58 rows=1 width=21) (actual time=0.233..0.234 rows=0 loops=1)
   ->  Sort  (cost=51.57..51.58 rows=1 width=21) (actual time=0.233..0.233 rows=0 loops=1)
         Sort Key: id
         Sort Method: quicksort  Memory: 25kB
         ->  Seq Scan on runs  (cost=0.00..51.56 rows=1 width=21) (actual time=0.229..0.229 rows=0 loops=1)
               Filter: (((org_id)::text = '5318290'::text) AND (correlation_id = '7978185d-88c8-47f3-8273-bbeaf67d67c9'::uuid))
               Rows Removed by Filter: 1104
 Planning Time: 0.112 ms
 Execution Time: 0.274 ms
(9 rows)

playbook-dispatcher=# CREATE INDEX concurrently if not exists runs_org_id_service_created_at_desc_index ON runs (org_id, correlation_id, id);
CREATE INDEX
playbook-dispatcher=# explain analyze                                                                                                        
SELECT "id","status","response_full" FROM "runs" WHERE (org_id = '5318290') AND (correlation_id = '7978185d-88c8-47f3-8273-bbeaf67d67c9') ORDER BY "runs"."id" LIMIT 50

;

```

create index


```
playbook-dispatcher=# explain analyze 
SELECT "id","status","response_full" FROM "runs" WHERE (org_id = '5318290') AND (correlation_id = '7978185d-88c8-47f3-8273-bbeaf67d67c9') ORDER BY "runs"."id" LIMIT 50

;
                                                                      QUERY PLAN                                                                       
-------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.28..8.30 rows=1 width=21) (actual time=0.010..0.010 rows=0 loops=1)
   ->  Index Scan using runs_org_id_service_created_at_desc_index on runs  (cost=0.28..8.30 rows=1 width=21) (actual time=0.008..0.008 rows=0 loops=1)
         Index Cond: (((org_id)::text = '5318290'::text) AND (correlation_id = '7978185d-88c8-47f3-8273-bbeaf67d67c9'::uuid))
 Planning Time: 0.106 ms
 Execution Time: 0.021 ms
(5 rows)


```
