### PR TITLE
RHCLOUD-34086 Configure CPU and Memory requests as variables

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -180,11 +180,11 @@ objects:
 
         resources:
           limits:
-            cpu: ${CPU_LIMIT}
-            memory: ${MEMORY_LIMIT}
+            cpu: ${API_CPU_LIMIT}
+            memory: ${API_MEMORY_LIMIT}
           requests:
-            cpu: ${CPU_REQUEST}
-            memory: ${MEMORY_REQUEST}
+            cpu: ${API_CPU_REQUEST}
+            memory: ${API_MEMORY_REQUEST}
 
     - name: response-consumer
       minReplicas: ${{REPLICAS_RESPONSE_CONSUMER}}
@@ -226,11 +226,11 @@ objects:
             value: ${DB_SSLMODE}
         resources:
           limits:
-            cpu: ${CPU_LIMIT}
-            memory: ${MEMORY_LIMIT}
+            cpu: ${RESPONSE_CONSUMER_CPU_LIMIT}
+            memory: ${RESPONSE_CONSUMER_MEMORY_LIMIT}
           requests:
-            cpu: ${CPU_REQUEST}
-            memory: ${MEMORY_REQUEST}
+            cpu: ${RESPONSE_CONSUMER_CPU_REQUEST}
+            memory: ${RESPONSE_CONSUMER_MEMORY_REQUEST}
 
     - name: validator
       minReplicas: ${{REPLICAS_VALIDATOR}}
@@ -273,11 +273,11 @@ objects:
             value: ${BLOCKLIST_ORG_IDS}
         resources:
           limits:
-            cpu: ${CPU_LIMIT}
-            memory: ${MEMORY_LIMIT}
+            cpu: ${VALIDATOR_CPU_LIMIT}
+            memory: ${VALIDATOR_MEMORY_LIMIT}
           requests:
-            cpu: ${CPU_REQUEST}
-            memory: ${MEMORY_REQUEST}
+            cpu: ${VALIDATOR_CPU_REQUEST}
+            memory: ${VALIDATOR_MEMORY_REQUEST}
 
     jobs:
     - name: cleaner
@@ -312,13 +312,29 @@ parameters:
 
 - name: LOG_LEVEL
   value: INFO
-- name: CPU_LIMIT
+- name: API_CPU_LIMIT
   value: 500m
-- name: CPU_REQUEST
+- name: API_CPU_REQUEST
   value: 250m
-- name: MEMORY_LIMIT
+- name: API_MEMORY_LIMIT
   value: 512Mi
-- name: MEMORY_REQUEST
+- name: API_MEMORY_REQUEST
+  value: 256Mi
+- name: RESPONSE_CONSUMER_CPU_LIMIT
+  value: 500m
+- name: RESPONSE_CONSUMER_CPU_REQUEST
+  value: 250m
+- name: RESPONSE_CONSUMER_MEMORY_LIMIT
+  value: 512Mi
+- name: RESPONSE_CONSUMER_MEMORY_REQUEST
+  value: 256Mi
+- name: VALIDATOR_CPU_LIMIT
+  value: 500m
+- name: VALIDATOR_CPU_REQUEST
+  value: 250m
+- name: VALIDATOR_MEMORY_LIMIT
+  value: 512Mi
+- name: VALIDATOR_MEMORY_REQUEST
   value: 256Mi
 
 - name: REPLICAS_API

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -183,8 +183,8 @@ objects:
             cpu: ${CPU_LIMIT}
             memory: ${MEMORY_LIMIT}
           requests:
-            cpu: 250m
-            memory: 256Mi
+            cpu: ${CPU_REQUEST}
+            memory: ${MEMORY_REQUEST}
 
     - name: response-consumer
       minReplicas: ${{REPLICAS_RESPONSE_CONSUMER}}
@@ -229,8 +229,8 @@ objects:
             cpu: ${CPU_LIMIT}
             memory: ${MEMORY_LIMIT}
           requests:
-            cpu: 250m
-            memory: 256Mi
+            cpu: ${CPU_REQUEST}
+            memory: ${MEMORY_REQUEST}
 
     - name: validator
       minReplicas: ${{REPLICAS_VALIDATOR}}
@@ -276,8 +276,8 @@ objects:
             cpu: ${CPU_LIMIT}
             memory: ${MEMORY_LIMIT}
           requests:
-            cpu: 250m
-            memory: 256Mi
+            cpu: ${CPU_REQUEST}
+            memory: ${MEMORY_REQUEST}
 
     jobs:
     - name: cleaner
@@ -314,8 +314,12 @@ parameters:
   value: INFO
 - name: CPU_LIMIT
   value: 500m
+- name: CPU_REQUEST
+  value: 250m
 - name: MEMORY_LIMIT
   value: 512Mi
+- name: MEMORY_REQUEST
+  value: 256Mi
 
 - name: REPLICAS_API
   value: "3"

--- a/deploy/connect.yaml
+++ b/deploy/connect.yaml
@@ -43,6 +43,14 @@ parameters:
   value: 2Gi
 - name: MEMORY_LIMITS
   value: 4Gi
+- name: EVENT_CONSUMER_CPU_REQUESTS
+  value: 100m
+- name: EVENT_CONSUMER_CPU_LIMITS
+  value: 200m
+- name: EVENT_CONSUMER_MEMORY_REQUESTS
+  value: 128Mi
+- name: EVENT_CONSUMER_MEMORY_LIMITS
+  value: 256Mi
 - name: XMX
   value: 4G
 - name: XMS
@@ -336,11 +344,11 @@ objects:
           name: playbook-dispatcher-event-consumer
           resources:
             requests:
-              cpu: 100m
-              memory: 128Mi
+              cpu: ${EVENT_CONSUMER_CPU_REQUESTS}
+              memory: ${EVENT_CONSUMER_MEMORY_REQUESTS}
             limits:
-              cpu: 200m
-              memory: 256Mi
+              cpu: ${EVENT_CONSUMER_CPU_LIMITS}
+              memory: ${EVENT_CONSUMER_MEMORY_LIMITS}
 
 # this service is only used in ephemeral to give the ephemeral kafka a stable address
 - apiVersion: v1

--- a/deploy/connect.yaml
+++ b/deploy/connect.yaml
@@ -35,21 +35,21 @@ parameters:
   value: '1'
 - name: VERSION
   value: '2.7.1'
-- name: CPU_REQUESTS
+- name: CPU_REQUEST
   value: 500m
-- name: CPU_LIMITS
+- name: CPU_LIMIT
   value: '1'
-- name: MEMORY_REQUESTS
+- name: MEMORY_REQUEST
   value: 2Gi
-- name: MEMORY_LIMITS
+- name: MEMORY_LIMIT
   value: 4Gi
-- name: EVENT_CONSUMER_CPU_REQUESTS
+- name: EVENT_CONSUMER_CPU_REQUEST
   value: 100m
-- name: EVENT_CONSUMER_CPU_LIMITS
+- name: EVENT_CONSUMER_CPU_LIMIT
   value: 200m
-- name: EVENT_CONSUMER_MEMORY_REQUESTS
+- name: EVENT_CONSUMER_MEMORY_REQUEST
   value: 128Mi
-- name: EVENT_CONSUMER_MEMORY_LIMITS
+- name: EVENT_CONSUMER_MEMORY_LIMIT
   value: 256Mi
 - name: XMX
   value: 4G
@@ -195,11 +195,11 @@ objects:
     replicas: ${{NUM_REPLICAS}}
     resources:
       limits:
-        cpu: ${CPU_LIMITS}
-        memory: ${MEMORY_LIMITS}
+        cpu: ${CPU_LIMIT}
+        memory: ${MEMORY_LIMIT}
       requests:
-        cpu: ${CPU_REQUESTS}
-        memory: ${MEMORY_REQUESTS}
+        cpu: ${CPU_REQUEST}
+        memory: ${MEMORY_REQUEST}
     jvmOptions:
       "-Xmx": ${XMX}
       "-Xms": ${XMS}
@@ -344,11 +344,11 @@ objects:
           name: playbook-dispatcher-event-consumer
           resources:
             requests:
-              cpu: ${EVENT_CONSUMER_CPU_REQUESTS}
-              memory: ${EVENT_CONSUMER_MEMORY_REQUESTS}
+              cpu: ${EVENT_CONSUMER_CPU_REQUEST}
+              memory: ${EVENT_CONSUMER_MEMORY_REQUEST}
             limits:
-              cpu: ${EVENT_CONSUMER_CPU_LIMITS}
-              memory: ${EVENT_CONSUMER_MEMORY_LIMITS}
+              cpu: ${EVENT_CONSUMER_CPU_LIMIT}
+              memory: ${EVENT_CONSUMER_MEMORY_LIMIT}
 
 # this service is only used in ephemeral to give the ephemeral kafka a stable address
 - apiVersion: v1


### PR DESCRIPTION
## What?
Use vars to define CPU and Memory requests instead of hard-coded values

## Why?
So we can configure CPU and Memory usage at deployment depending on env

