### PR TITLE
Publishing that host objects are limited to fifty per batch

### DIFF
--- a/schema/private.openapi.yaml
+++ b/schema/private.openapi.yaml
@@ -106,7 +106,7 @@ paths:
           application/json:
             schema:
               type: array
-              items: 
+              items:
                 $ref: '#/components/schemas/CancelInputV2'
               minItems: 1
               maxItems: 50
@@ -205,7 +205,7 @@ components:
       - run_id
       - org_id
       - principal
-    
+
     RunCanceled:
       type: object
       properties:
@@ -248,7 +248,7 @@ components:
           type: integer
           example: 201
           description: status code of the request
-        message: 
+        message:
           type: string
           example: "Unexpected error during processing"
           description: Error Message
@@ -315,6 +315,8 @@ components:
             description: Identifies a record of the Host-Inventory service
             type: string
             minLength: 1
+          minItems: 1
+          maxItems: 50
       required:
       - org_id
       - hosts
@@ -365,7 +367,7 @@ components:
       type: string
       format: sat-id-uuid
       example: aa3b1faa-56f3-4d14-8258-615d11e20060
-    
+
     SatelliteOrgId:
       description: Identifier of the organization within Satellite
       type: string


### PR DESCRIPTION
## What?
Inventory limits us to lists of at most fifty hosts.  We need to publish that we too
are limited to fifty hosts, because more than this get silently discarded.

## Why?
Make sure that users of our API, particularly the /internal/v2/connection_status
path, do not send us more than fifty hosts at a time.

## How?
Update the private OpenAPI schema.

## Testing
No, I don't know how this is tested in golang.

## Anything Else?
This is related to https://issues.redhat.com/browse/RHCLOUD-33751

## Secure Coding Checklist
- [NA] Input Validation
- [NA] Output Encoding
- [NA] Authentication and Password Management
- [NA] Session Management
- [NA] Access Control
- [NA] Cryptographic Practices
- [NA] Error Handling and Logging
- [NA] Data Protection
- [NA] Communication Security
- [NA] System Configuration
- [NA] Database Security
- [NA] File Management
- [NA] Memory Management
- [NA] General Coding Practices
