### PR TITLE
Revert "Testing...if hosts is empty, just set it to []string{'localhost'} (#445)"

### DIFF
--- a/internal/response-consumer/handler.go
+++ b/internal/response-consumer/handler.go
@@ -133,8 +133,7 @@ func (this *handler) onMessage(ctx context.Context, msg *k.Message) {
 			hosts := ansible.GetAnsibleHosts(*value.RunnerEvents)
 
 			if len(hosts) == 0 {
-				utils.GetLogFromContext(ctx).Info("hosts is empty...set hosts to localhost")
-				hosts = []string{"localhost"}
+				return nil
 			}
 
 			toCreate = mapHostsToRunHosts(hosts, func(host string) db.RunHost {


### PR DESCRIPTION
This reverts commit 45d9f9acd3eac1ca495aed711962b1d9c91a959d.

This was just used for testing.  I need to push this specific kafka connect config to prod Thursday for the db upgrade, but I do not want to include this change.  So ...cut it out for now.