### PR TITLE
Revert "Reconfigure connect for postgres 16 (#448)"

### DIFF
--- a/deploy/connect.yaml
+++ b/deploy/connect.yaml
@@ -262,7 +262,7 @@ objects:
 - apiVersion: kafka.strimzi.io/v1beta2
   kind: KafkaConnector
   metadata:
-    name: playbook-dispatcher-event-interface-16
+    name: playbook-dispatcher-event-interface
     labels:
       app: playbook-dispatcher
       strimzi.io/cluster: playbook-dispatcher-connect
@@ -308,8 +308,6 @@ objects:
         heartbeat.interval.ms: 600000
         topic.heartbeat.prefix: "__debezium-heartbeat-pd"
         heartbeat.action.query: "INSERT INTO public.runs (id, org_id, recipient, correlation_id, url, service, timeout, created_at, updated_at) VALUES ('98875b33-b37e-4c35-be8b-d74f321bac28', '5318290', '00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000', 'https://redhat.com', 'heartbeat', 3600, NOW(), NOW()) ON CONFLICT(id) DO UPDATE SET updated_at=NOW();"
-
-        snapshot.mode: never
 
 - apiVersion: apps/v1
   kind: Deployment


### PR DESCRIPTION
This reverts commit a281c9ae812c7e896fefa19e1dd817258f36d64b.

This change was not required and it didn't get pushed out to stage or prod (my mistake).  I'm reverting it for now.