### PR TITLE
Fix default sort_by value for the /runs endpoint in the openapi spec

### DIFF
--- a/schema/public.openapi.yaml
+++ b/schema/public.openapi.yaml
@@ -460,6 +460,7 @@ components:
           - created_at
           - created_at:asc
           - created_at:desc
+        default: created_at:desc
 
     Limit:
       description: Maximum number of results to return


### PR DESCRIPTION
Fix default sort_by value for the /runs endpoint in the openapi spec.

This fixes a failing test.