### PR TITLE
UBI 9 does not have golang 1.23 which the latest version of go-jsonsc…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: init generate build test run-lint
 
 init:
 	go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
-	go install github.com/atombender/go-jsonschema@latest
+	go install github.com/atombender/go-jsonschema@v0.17.0
 	go install github.com/kulshekhar/fungen@latest
 
 generate-api: internal/api/controllers/public/spec.gen.go \


### PR DESCRIPTION
UBI 9 does not have golang 1.23 which the latest version of go-jsonschema depends on.  Pin go-jsonschema to a version that builds with golang 1.22.

When building locally golang, magically decides to use go 1.23 to build and it just prints out an (easy to miss) warning message.  Our pr checks seem to do the same.  Building the image on UBI9 however blows up.