### PR TITLE
RHCLOUD-38509 Allow suspending the cleaner job from env var

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -282,6 +282,7 @@ objects:
     jobs:
     - name: cleaner
       schedule: ${CLEANER_SCHEDULE}
+      suspend: ${{SUSPEND_CLEANER}}
       restartPolicy: OnFailure
       concurrencyPolicy: Replace
       podSpec:
@@ -377,6 +378,9 @@ parameters:
 
 - name: CLEANER_SCHEDULE
   value: "*/10 * * * *"
+- name: SUSPEND_CLEANER
+  description: Should the cleaner job be suspended?
+  value: "false"
 
 - name: TENANT_TRANSLATOR_HOST
   required: true


### PR DESCRIPTION
## What?
https://issues.redhat.com/browse/RHCLOUD-38509

This PR makes it possible to suspend the cleaner job from an env var: `SUSPEND_CLEANER=true`.

## Why?
Consider what business or engineering goal does this PR achieves.

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
