### PR TITLE
RHCLOUD-33628: Set the message key as 'message'

### DIFF
--- a/internal/api/tests/public/middleware_test.go
+++ b/internal/api/tests/public/middleware_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"playbook-dispatcher/internal/common/utils/test"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -18,7 +17,6 @@ var _ = Describe("Middleware", func() {
 
 		It("attaches request id to the response", func() {
 			const requestId = "33ee136c-da81-4a68-953c-c22bdd096d30"
-			time.Sleep(30 * time.Second)
 
 			req, err := http.NewRequest(http.MethodGet, "http://localhost:9002/api/playbook-dispatcher/v1/runs", nil)
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/api/tests/public/middleware_test.go
+++ b/internal/api/tests/public/middleware_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"playbook-dispatcher/internal/common/utils/test"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -17,6 +18,7 @@ var _ = Describe("Middleware", func() {
 
 		It("attaches request id to the response", func() {
 			const requestId = "33ee136c-da81-4a68-953c-c22bdd096d30"
+			time.Sleep(30 * time.Second)
 
 			req, err := http.NewRequest(http.MethodGet, "http://localhost:9002/api/playbook-dispatcher/v1/runs", nil)
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/common/utils/logging.go
+++ b/internal/common/utils/logging.go
@@ -26,6 +26,8 @@ func GetLoggerOrDie() *zap.SugaredLogger {
 		cfg := config.Get()
 
 		logCfg := zap.NewProductionConfig()
+		logCfg.EncoderConfig.MessageKey = "message"
+
 		err := logCfg.Level.UnmarshalText([]byte(cfg.GetString("log.level")))
 		if err != nil {
 			DieOnError(err)

--- a/internal/common/utils/logging.go
+++ b/internal/common/utils/logging.go
@@ -27,7 +27,6 @@ func GetLoggerOrDie() *zap.SugaredLogger {
 
 		logCfg := zap.NewProductionConfig()
 		err := logCfg.Level.UnmarshalText([]byte(cfg.GetString("log.level")))
-
 		if err != nil {
 			DieOnError(err)
 		}
@@ -78,8 +77,11 @@ func createCloudwatch(cfg *viper.Viper, level zap.AtomicLevel) (zap.Option, erro
 		return nil, err
 	}
 
+	encoderConfig := zap.NewProductionEncoderConfig()
+	encoderConfig.MessageKey = "message"
+
 	cwc := zapcore.NewCore(
-		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+		zapcore.NewJSONEncoder(encoderConfig),
 		zapcore.AddSync(writer),
 		zap.NewAtomicLevelAt(level.Level()),
 	)


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Set the message key to 'message' in the JSON encoder configuration for CloudWatch logging.