### PR TITLE
Konflux build pipeline service account migration

### DIFF
--- a/.tekton/playbook-dispatcher-pull-request.yaml
+++ b/.tekton/playbook-dispatcher-pull-request.yaml
@@ -37,7 +37,8 @@ spec:
     - name: pathInRepo
       value: pipelines/docker-build-oci-ta.yaml
     resolver: git
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-playbook-dispatcher
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/playbook-dispatcher-push.yaml
+++ b/.tekton/playbook-dispatcher-push.yaml
@@ -34,7 +34,8 @@ spec:
     - name: pathInRepo
       value: pipelines/docker-build-oci-ta.yaml
     resolver: git
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-playbook-dispatcher
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
## Build pipeline Service Account migration

This PR changes Service Account used by build pipeline from "appstudio-pipeline" to dedicated to the Component Service Account.
Please merge the Service Account update to avoid broken builds when deprected "appstudio-pipeline" Service Account is removed.

## Summary by Sourcery

CI:
- Specify 'build-pipeline-playbook-dispatcher' as the serviceAccountName in .tekton/playbook-dispatcher-pull-request.yaml