### PR TITLE
Add psk for qe's post-deploy tests

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -114,6 +114,13 @@ objects:
                 key: key
                 name: auth-psk-tasks
                 optional: true
+          - name: PSK_AUTH_QE_TESTS
+            valueFrom:
+              secretKeyRef:
+                key: key
+                name: auth-psk-qe-tests
+                optional: true
+
           - name: PSK_AUTH_TEST
             value: ${PSK_AUTH_TEST}
 


### PR DESCRIPTION
## What?
Add psk for qe's post-deploy tests

## Summary by Sourcery

Deployment:
- Add PSK_AUTH_QE_TESTS env var referencing the auth-psk-qe-tests secret in deploy/clowdapp.yaml