### PR TITLE
RHINENG-19548: Update java image

### DIFF
--- a/event-streams/Dockerfile
+++ b/event-streams/Dockerfile
@@ -26,7 +26,7 @@ RUN ./mvnw -Dschema.event.run=/src/run.event.yaml -Dschema.event.run.host=/src/r
 
 
 # https://access.redhat.com/documentation/en-us/red_hat_amq/2021.q3/html-single/deploying_and_upgrading_amq_streams_on_openshift/index#creating-new-image-from-base-str
-FROM registry.redhat.io/amq-streams/kafka-39-rhel9:2.9.0-4
+FROM registry.redhat.io/amq-streams/kafka-39-rhel9:2.9.1-2
 ARG BUILD_COMMIT=unknown
 
 ENV CONNECT_PLUGIN_PATH=/opt/kafka/plugins \


### PR DESCRIPTION
Updating Java image to the latest Red Hat releases.

## Summary by Sourcery

Enhancements:
- Bump the AMQ Streams Kafka RHEL9 base image from version 2.9.0-4 to 2.9.1-2