### PR TITLE
add coverage to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,10 @@ run-sasl: migrate-db
 test: migrate-db
 	SCHEMA_API_PRIVATE=$(shell pwd)/schema/private.openapi.yaml ACG_CONFIG=$(shell pwd)/cdappconfig.json PSK_AUTH_TEST=xwKhCUzgJ8 PSK_AUTH_TEST02=9yh9WuXWDj go test -p 1 -v ./...
 
+test-coverage: migrate-db
+	SCHEMA_API_PRIVATE=$(shell pwd)/schema/private.openapi.yaml ACG_CONFIG=$(shell pwd)/cdappconfig.json PSK_AUTH_TEST=xwKhCUzgJ8 PSK_AUTH_TEST02=9yh9WuXWDj go test -p 1 -v ./... -coverprofile=/tmp/coverage.out
+	go tool cover -html=/tmp/coverage.out
+
 sample_request:
 	curl -v -H "content-type: application/json" -H "Authorization: PSK xwKhCUzgJ8" -d "@examples/payload.json" http://localhost:8000/internal/dispatch
 


### PR DESCRIPTION
## What?
Adding a golang coverage option to the Makefile

## Why?
Makes it straightforward to test with coverage enabled and see the results via web browser

## How?
Add the definition to the Makefile

## Testing
N/A

## Summary by Sourcery

Enhancements:
- Introduce 'test-coverage' Makefile target to generate a coverage profile and open it in HTML