### PR TITLE
Use Konflux images in ephemeral

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -355,7 +355,7 @@ parameters:
 - name: IMAGE_TAG
   required: true
 - name: IMAGE
-  value: quay.io/cloudservices/playbook-dispatcher
+  value: quay.io/redhat-services-prod/hcc-integrations-tenant/playbook-dispatcher
 - description : ClowdEnvironment name
   name: ENV_NAME
   required: true

--- a/deploy/connect-msk.yaml
+++ b/deploy/connect-msk.yaml
@@ -4,7 +4,7 @@ metadata:
   name: playbook-dispatcher-connect
 parameters:
 - name: KAFKA_CONNECT_IMAGE
-  value: quay.io/cloudservices/playbook-dispatcher-connect
+  value: quay.io/redhat-services-prod/hcc-integrations-tenant/playbook-dispatcher-connect
 - name: IMAGE_TAG
   value: latest
 - name: KAFKA_BOOTSTRAP_HOST

--- a/deploy/connect.yaml
+++ b/deploy/connect.yaml
@@ -4,7 +4,7 @@ metadata:
   name: playbook-dispatcher-connect
 parameters:
 - name: KAFKA_CONNECT_IMAGE
-  value: quay.io/cloudservices/playbook-dispatcher-connect
+  value: quay.io/redhat-services-prod/hcc-integrations-tenant/playbook-dispatcher-connect
 - name: IMAGE_TAG
   value: latest
 - name: KAFKA_BOOTSTRAP_HOST


### PR DESCRIPTION
## What?
This PR changes the path to the `playbook-dispatcher` and `playbook-dispatcher-connect` images in Quay, from the old images (cloudservices) to the new ones released from Konflux.

## Why?
All deployments in ephemeral are currently pulling images from the cloudservices repos, which is wrong.

## Summary by Sourcery

Update ephemeral deployments to use the new Konflux quay image paths for playbook-dispatcher services

Enhancements:
- Replace quay.io/cloudservices/playbook-dispatcher with quay.io/redhat-services-prod/hcc-integrations-tenant/playbook-dispatcher in clowdapp.yaml
- Replace quay.io/cloudservices/playbook-dispatcher-connect with quay.io/redhat-services-prod/hcc-integrations-tenant/playbook-dispatcher-connect in connect-msk.yaml and connect.yaml