### PR TITLE
Revert "Use Konflux images in ephemeral"

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -355,7 +355,7 @@ parameters:
 - name: IMAGE_TAG
   required: true
 - name: IMAGE
-  value: quay.io/redhat-services-prod/hcc-integrations-tenant/playbook-dispatcher
+  value: quay.io/cloudservices/playbook-dispatcher
 - description : ClowdEnvironment name
   name: ENV_NAME
   required: true

--- a/deploy/connect-msk.yaml
+++ b/deploy/connect-msk.yaml
@@ -4,7 +4,7 @@ metadata:
   name: playbook-dispatcher-connect
 parameters:
 - name: KAFKA_CONNECT_IMAGE
-  value: quay.io/redhat-services-prod/hcc-integrations-tenant/playbook-dispatcher-connect
+  value: quay.io/cloudservices/playbook-dispatcher-connect
 - name: IMAGE_TAG
   value: latest
 - name: KAFKA_BOOTSTRAP_HOST

--- a/deploy/connect.yaml
+++ b/deploy/connect.yaml
@@ -4,7 +4,7 @@ metadata:
   name: playbook-dispatcher-connect
 parameters:
 - name: KAFKA_CONNECT_IMAGE
-  value: quay.io/redhat-services-prod/hcc-integrations-tenant/playbook-dispatcher-connect
+  value: quay.io/cloudservices/playbook-dispatcher-connect
 - name: IMAGE_TAG
   value: latest
 - name: KAFKA_BOOTSTRAP_HOST


### PR DESCRIPTION
Reverts RedHatInsights/playbook-dispatcher#528

Opening revert PR per Pavol to test.

## Summary by Sourcery

Revert the use of Konflux image paths by restoring the original quay.io/cloudservices registry references in deployment manifests

Bug Fixes:
- Restore the IMAGE parameter in clowdapp.yaml to quay.io/cloudservices/playbook-dispatcher
- Restore the KAFKA_CONNECT_IMAGE in connect-msk.yaml to quay.io/cloudservices/playbook-dispatcher-connect
- Restore the KAFKA_CONNECT_IMAGE in connect.yaml to quay.io/cloudservices/playbook-dispatcher-connect