### PR TITLE
RHINENG-19114; update prefix in clowdapp.yml file to resolve invalid path and permissions issues

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -323,7 +323,7 @@ objects:
     suspend: ${{FLOORIST_SUSPEND}}
     disabled: ${{FLOORIST_DISABLED}}
     queries:
-      - prefix: insights/playbook-dispatcher/run_hosts
+      - prefix: hms_analytics/playbook-dispatcher/run_hosts
         query: >-
           SELECT id,
                   run_id,
@@ -333,7 +333,7 @@ objects:
                   updated_at,
                   sat_sequence
           FROM run_hosts;
-      - prefix: insights/playbook-dispatcher/runs
+      - prefix: hms_analytics/playbook-dispatcher/runs
         query: >-
           SELECT id, 
                   recipient, 


### PR DESCRIPTION
## What?
As title states

## Why?
Incorrect value provided in previous config, we do not have write permissions for the path we dont want to be in 

## How?
n/a

## Testing
n/a

## Anything Else?
n/a

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Bug Fixes:
- Update prefix for run_hosts and runs queries from insights/playbook-dispatcher to hms_analytics/playbook-dispatcher in clowdapp.yaml to resolve invalid path and permission issues.