### PR TITLE
RHINENG-19114; updating clowdapp file to specify UUID fields as TEXT for floorist compliance, updating HMS bucket secret

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -325,21 +325,22 @@ objects:
     queries:
       - prefix: hms_analytics/playbook-dispatcher/run_hosts
         query: >-
-          SELECT id,
-                  run_id,
-                  inventory_id,
-                  status,
+          SELECT id::TEXT,
+                  run_id::TEXT,
+                  inventory_id::TEXT,
+                  status::TEXT,
                   created_at,
                   updated_at,
-                  sat_sequence
+                  sat_sequence,
+                  subscription_manager_id::TEXT
           FROM run_hosts;
       - prefix: hms_analytics/playbook-dispatcher/runs
         query: >-
-          SELECT id, 
-                  recipient, 
-                  correlation_id, 
+          SELECT id::TEXT, 
+                  recipient::TEXT, 
+                  correlation_id::TEXT, 
                   url, 
-                  status, 
+                  status::TEXT, 
                   created_at, 
                   updated_at, 
                   timeout, 
@@ -348,7 +349,7 @@ objects:
                   playbook_name, 
                   playbook_run_url, 
                   principal, 
-                  sat_id, 
+                  sat_id::TEXT, 
                   sat_org_id 
           FROM runs;
 


### PR DESCRIPTION
## What?
Floorist seems to be complaining about UUID fields, so we're going to tell it to treat UUID's as text for metrics collection

## Why?
For metrics collection

## How?
Select statements for this service will select relevant fields as text

## Testing
n/a

## Anything Else?
n/a

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Cast UUID fields to TEXT in SQL queries within the clowdapp deployment config for Floorist metrics compliance

Enhancements:
- Add ::TEXT casts to id, run_id, inventory_id, status, subscription_manager_id and related UUID fields in playbook-dispatcher/run_hosts and playbook-dispatcher/runs queries

Deployment:
- Update deploy/clowdapp.yaml to treat UUID fields as TEXT