### PR TITLE
chore(docker): update Kafka base image to version 2.9.2-1

### DIFF
--- a/event-streams/Dockerfile
+++ b/event-streams/Dockerfile
@@ -26,7 +26,7 @@ RUN ./mvnw -Dschema.event.run=/src/run.event.yaml -Dschema.event.run.host=/src/r
 
 
 # https://access.redhat.com/documentation/en-us/red_hat_amq/2021.q3/html-single/deploying_and_upgrading_amq_streams_on_openshift/index#creating-new-image-from-base-str
-FROM registry.redhat.io/amq-streams/kafka-39-rhel9:2.9.1-2
+FROM registry.redhat.io/amq-streams/kafka-39-rhel9:2.9.2-1
 ARG BUILD_COMMIT=unknown
 
 ENV CONNECT_PLUGIN_PATH=/opt/kafka/plugins \


### PR DESCRIPTION
## Title
chore(docker): update Kafka base image to version 2.9.2-1

Fixes: RHINENG-20761

## Overview
Upgrades the Kafka base image in the Dockerfile from version 2.9.1-2 to 2.9.2-1 to incorporate the latest updates and fixes.

## Why?
Regular maintenance and dependency updates