### PR TITLE
RHINENG-19114; update floorist queries to utilize env based prefixes and only look at last month's data

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -323,7 +323,7 @@ objects:
     suspend: ${{FLOORIST_SUSPEND}}
     disabled: ${{FLOORIST_DISABLED}}
     queries:
-      - prefix: hms_analytics/playbook-dispatcher/run_hosts
+      - prefix: ${FLOORIST_QUERY_PREFIX}/run_hosts
         query: >-
           SELECT id::TEXT,
                   run_id::TEXT,
@@ -333,8 +333,10 @@ objects:
                   updated_at,
                   sat_sequence,
                   subscription_manager_id::TEXT
-          FROM run_hosts;
-      - prefix: hms_analytics/playbook-dispatcher/runs
+          FROM run_hosts 
+          WHERE created_at >= DATE_TRUNC('month', NOW() - INTERVAL '1 month');
+
+      - prefix: ${FLOORIST_QUERY_PREFIX}/runs
         query: >-
           SELECT id::TEXT, 
                   recipient::TEXT, 
@@ -351,7 +353,8 @@ objects:
                   principal, 
                   sat_id::TEXT, 
                   sat_org_id 
-          FROM runs;
+          FROM runs
+          WHERE created_at >= DATE_TRUNC('month', NOW() - INTERVAL '1 month');
 
 parameters:
 - name: IMAGE_TAG
@@ -473,20 +476,35 @@ parameters:
 - name: KEY_CLOUD_CONNECTOR
   value: cloud_connector
 
-# Used for floorist
+# Global Floorist Values
+
+- name: FLOORIST_DB_SECRET_NAME
+  description: database secret name
+  value: playbook-dispatcher-db
+
+- name: FLOORIST_HMS_BUCKET_SECRET_NAME
+  description: HMS bucket secret name
+  value: hms-floorist-bucket
+
 - name: FLOORIST_SUSPEND
   description: Disable Floorist cronjob execution
   required: true
   value: 'true'
+
 - name: FLOORIST_DISABLED
   description: Determines whether to build the Floorist Job.
   value: 'false'
-- name: FLOORIST_DB_SECRET_NAME
-  description: database secret name
-  value: playbook-dispatcher-db
-- name: FLOORIST_HMS_BUCKET_SECRET_NAME
-  description: HMS bucket secret name
-  value: hms-floorist-bucket
+
 - name: FLOORIST_LOGLEVEL
   description: Floorist loglevel config
   value: 'INFO'
+
+- name: FLOORIST_QUERY_PREFIX
+  description: Prefix for separating query data between prod and stage in the bucket
+  value: "hms_analytics/playbook-dispatcher/unknown"
+
+#- name: FLOORIST_SCHEDULE
+#  description: Cronjob schedule definition
+#  required: true
+# Run at 00:00 on first day of month
+#  value: "0 0 1 * *"


### PR DESCRIPTION
## What?
Update queries to include only last month's data and store data based on what env its running in.

## Why?
To address issues in metrics collection in production by enabling stage queries first.

## How?
Query will now send data based on a prefix passed to it by app-interface that specifies what env we're in.  Data stored will only contain the previous month's data.

## Testing
n/a

## Anything Else?
n/a

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
