### PR TITLE
RHINENG-23325: fix unknown userid for kessel check

### DIFF
--- a/internal/api/middleware/rbac.go
+++ b/internal/api/middleware/rbac.go
@@ -27,6 +27,51 @@ type allowedServicesKeyType int
 const permissionsKey permissionsKeyType = iota
 const allowedServicesKey allowedServicesKeyType = iota
 
+// identityContext holds extracted identity information for logging and authorization
+type identityContext struct {
+	OrgID        string
+	IdentityType string
+	UserID       string
+}
+
+// extractIdentityContext extracts identity information from XRHID
+// useFallbacks controls whether to use "unknown" for missing values
+func extractIdentityContext(xrhid identity.XRHID, useFallbacks bool) identityContext {
+	ctx := identityContext{
+		OrgID:        xrhid.Identity.OrgID,
+		IdentityType: xrhid.Identity.Type,
+	}
+
+	// Set fallbacks for missing org/type if requested
+	if useFallbacks {
+		if ctx.OrgID == "" {
+			ctx.OrgID = "unknown"
+		}
+		if ctx.IdentityType == "" {
+			ctx.IdentityType = "unknown"
+		}
+	}
+
+	// Extract user ID based on identity type with nil guards
+	switch ctx.IdentityType {
+	case "User":
+		if xrhid.Identity.User != nil {
+			ctx.UserID = xrhid.Identity.User.UserID
+		}
+	case "ServiceAccount":
+		if xrhid.Identity.ServiceAccount != nil {
+			ctx.UserID = xrhid.Identity.ServiceAccount.UserId
+		}
+	}
+
+	// Set fallback for userID if requested and still empty
+	if useFallbacks && ctx.UserID == "" {
+		ctx.UserID = "unknown"
+	}
+
+	return ctx
+}
+
 func EnforcePermissions(cfg *viper.Viper, requiredPermissions ...rbac.RequiredPermission) echo.MiddlewareFunc {
 	var client rbac.RbacClient
 
@@ -91,7 +136,40 @@ func EnforcePermissions(cfg *viper.Viper, requiredPermissions ...rbac.RequiredPe
 			}
 
 			// TIER 2: Service-level authorization
-			allowedServices := computeAllowedServices(c, permissions, mode, log)
+			// Extract identity context for error logging
+			xrhid := identity.GetIdentity(req.Context())
+			idCtx := extractIdentityContext(xrhid, false) // no fallbacks for error logging
+
+			allowedServices, err := computeAllowedServices(c, permissions, mode, log)
+			if err != nil {
+				// Distinguish error types for appropriate HTTP status codes
+				if kessel.IsIdentityValidationError(err) {
+					log.Errorw("Identity validation failed",
+						"error", err,
+						"mode", mode,
+						"org_id", idCtx.OrgID,
+						"identity_type", idCtx.IdentityType,
+						"user_id", idCtx.UserID)
+					return echo.NewHTTPError(http.StatusBadRequest, "invalid identity")
+				}
+				if kessel.IsServiceUnavailableError(err) {
+					log.Errorw("Authorization service unavailable",
+						"error", err,
+						"mode", mode,
+						"org_id", idCtx.OrgID,
+						"identity_type", idCtx.IdentityType,
+						"user_id", idCtx.UserID)
+					return echo.NewHTTPError(http.StatusServiceUnavailable, "authorization service unavailable")
+				}
+				// Other errors
+				log.Errorw("Authorization check failed",
+					"error", err,
+					"mode", mode,
+					"org_id", idCtx.OrgID,
+					"identity_type", idCtx.IdentityType,
+					"user_id", idCtx.UserID)
+				return echo.NewHTTPError(http.StatusInternalServerError, "authorization check failed")
+			}
 
 			// In Kessel-enforcing modes, empty allowedServices means no permissions (403)
 			if len(allowedServices) == 0 {
@@ -138,25 +216,36 @@ func GetAllowedServices(c echo.Context) []string {
 
 // computeAllowedServices determines which services the user can access
 // based on the authorization mode
-func computeAllowedServices(ctx echo.Context, rbacPermissions []rbac.Access, mode string, log *zap.SugaredLogger) []string {
+// Returns (services, error) where error can be typed (ErrIdentityValidation, ErrServiceUnavailable)
+func computeAllowedServices(ctx echo.Context, rbacPermissions []rbac.Access, mode string, log *zap.SugaredLogger) ([]string, error) {
 	switch mode {
 	case config.KesselModeRBACOnly:
 		log.Debugw("Using RBAC-only authorization mode")
-		return getRbacAllowedServices(rbacPermissions)
+		return getRbacAllowedServices(rbacPermissions), nil
 
 	case config.KesselModeBothRBACEnforces:
 		log.Debugw("Using both-rbac-enforces authorization mode (validation)")
 		rbacServices := getRbacAllowedServices(rbacPermissions)
-		kesselServices := getKesselAllowedServices(ctx, log)
-		logComparison(ctx, rbacServices, kesselServices, log)
-		return rbacServices
+		kesselServices, err := getKesselAllowedServices(ctx, log)
+		if err != nil {
+			// In validation mode, log the error but use RBAC results
+			log.Warnw("Kessel check failed in validation mode, using RBAC results",
+				"error", err)
+		} else {
+			logComparison(ctx, rbacServices, kesselServices, log)
+		}
+		return rbacServices, nil
 
 	case config.KesselModeBothKesselEnforces:
 		log.Debugw("Using both-kessel-enforces authorization mode (transition)")
 		rbacServices := getRbacAllowedServices(rbacPermissions)
-		kesselServices := getKesselAllowedServices(ctx, log)
+		kesselServices, err := getKesselAllowedServices(ctx, log)
+		if err != nil {
+			// In transition mode, return error since Kessel is enforcing
+			return nil, err
+		}
 		logComparison(ctx, rbacServices, kesselServices, log)
-		return kesselServices
+		return kesselServices, nil
 
 	case config.KesselModeKesselOnly:
 		log.Debugw("Using kessel-only authorization mode")
@@ -165,7 +254,7 @@ func computeAllowedServices(ctx echo.Context, rbacPermissions []rbac.Access, mod
 	default:
 		log.Warnw("Unknown Kessel authorization mode, falling back to RBAC",
 			"mode", mode)
-		return getRbacAllowedServices(rbacPermissions)
+		return getRbacAllowedServices(rbacPermissions), nil
 	}
 }
 
@@ -175,51 +264,22 @@ func getRbacAllowedServices(permissions []rbac.Access) []string {
 }
 
 // getKesselAllowedServices queries Kessel for allowed services
-func getKesselAllowedServices(ctx echo.Context, log *zap.SugaredLogger) []string {
+// Returns (services, error) where error can be typed (ErrIdentityValidation, ErrServiceUnavailable)
+func getKesselAllowedServices(ctx echo.Context, log *zap.SugaredLogger) ([]string, error) {
 	// Extract identity from context
 	xrhid := identity.GetIdentity(ctx.Request().Context())
-	orgID := xrhid.Identity.OrgID
-	identityType := xrhid.Identity.Type
-
-	// Provide fallback for missing identity fields
-	if orgID == "" {
-		orgID = "unknown"
-	}
-	if identityType == "" {
-		identityType = "unknown"
-	}
-
-	// Extract user ID based on identity type with nil guards
-	var userID string
-	switch identityType {
-	case "User":
-		if xrhid.Identity.User != nil {
-			userID = xrhid.Identity.User.UserID
-		}
-		if userID == "" {
-			userID = "unknown"
-		}
-	case "ServiceAccount":
-		if xrhid.Identity.ServiceAccount != nil {
-			userID = xrhid.Identity.ServiceAccount.UserId
-		}
-		if userID == "" {
-			userID = "unknown"
-		}
-	default:
-		userID = "unknown"
-	}
+	idCtx := extractIdentityContext(xrhid, true) // use fallbacks for Kessel logging
 
 	// Get workspace ID for the organization
-	workspaceID, err := kessel.GetWorkspaceID(ctx.Request().Context(), orgID, log)
+	workspaceID, err := kessel.GetWorkspaceID(ctx.Request().Context(), idCtx.OrgID, log)
 	if err != nil {
-		log.Errorw("Kessel authorization error",
+		log.Errorw("Kessel workspace lookup error",
 			"error", err,
-			"org_id", orgID,
-			"identity_type", identityType,
-			"user_id", userID)
+			"org_id", idCtx.OrgID,
+			"identity_type", idCtx.IdentityType,
+			"user_id", idCtx.UserID)
 		instrumentation.KesselAuthorizationError(ctx)
-		return []string{} // Return empty list on error
+		return nil, err // Return error for proper handling
 	}
 
 	// Check permissions via Kessel (uses V2ApplicationPermissions map)
@@ -242,32 +302,32 @@ func getKesselAllowedServices(ctx echo.Context, log *zap.SugaredLogger) []string
 	if err != nil {
 		log.Errorw("Kessel authorization error",
 			"error", err,
-			"org_id", orgID,
+			"org_id", idCtx.OrgID,
 			"workspace_id", workspaceID,
-			"identity_type", identityType,
-			"user_id", userID)
+			"identity_type", idCtx.IdentityType,
+			"user_id", idCtx.UserID)
 		instrumentation.KesselAuthorizationError(ctx)
-		return []string{} // Return empty list on error
+		return nil, err // Return error for proper handling
 	}
 
 	if len(allowedServices) == 0 {
 		log.Debugw("Kessel authorization returned no services",
-			"org_id", orgID,
+			"org_id", idCtx.OrgID,
 			"workspace_id", workspaceID,
-			"identity_type", identityType,
-			"user_id", userID)
+			"identity_type", idCtx.IdentityType,
+			"user_id", idCtx.UserID)
 		instrumentation.KesselAuthorizationFailed(ctx)
 	} else {
 		log.Debugw("Kessel authorization succeeded",
-			"org_id", orgID,
+			"org_id", idCtx.OrgID,
 			"workspace_id", workspaceID,
-			"identity_type", identityType,
-			"user_id", userID,
+			"identity_type", idCtx.IdentityType,
+			"user_id", idCtx.UserID,
 			"allowed_services", allowedServices)
 		instrumentation.KesselAuthorizationPassed(ctx)
 	}
 
-	return allowedServices
+	return allowedServices, nil
 }
 
 // logComparison compares RBAC and Kessel results and logs any discrepancies

--- a/internal/common/kessel/authorization.go
+++ b/internal/common/kessel/authorization.go
@@ -121,7 +121,7 @@ func checkPermissionInternal(
 
 		response, err := globalManager.client.KesselInventoryService.CheckForUpdate(ctx, request, opts...)
 		if err != nil {
-			return false, fmt.Errorf("Kessel check for update failed: %w", err)
+			return false, fmt.Errorf("%w: Kessel check for update failed: %v", ErrServiceUnavailable, err)
 		}
 		allowed = response.GetAllowed() == kesselv2.Allowed_ALLOWED_TRUE
 
@@ -152,7 +152,7 @@ func checkPermissionInternal(
 
 		response, err := globalManager.client.KesselInventoryService.Check(ctx, request, opts...)
 		if err != nil {
-			return false, fmt.Errorf("Kessel check failed: %w", err)
+			return false, fmt.Errorf("%w: Kessel check failed: %v", ErrServiceUnavailable, err)
 		}
 		allowed = response.GetAllowed() == kesselv2.Allowed_ALLOWED_TRUE
 
@@ -244,17 +244,17 @@ func extractUserID(xrhid identity.XRHID) (string, error) {
 	switch xrhid.Identity.Type {
 	case "User":
 		if xrhid.Identity.User == nil || xrhid.Identity.User.UserID == "" {
-			return "", errors.New("user ID is empty")
+			return "", fmt.Errorf("%w: user ID is empty", ErrIdentityValidation)
 		}
 		return xrhid.Identity.User.UserID, nil
 	case "ServiceAccount":
 		if xrhid.Identity.ServiceAccount == nil || xrhid.Identity.ServiceAccount.UserId == "" {
-			return "", errors.New("service account user ID is empty")
+			return "", fmt.Errorf("%w: service account user ID is empty", ErrIdentityValidation)
 		}
 		// Note: ServiceAccount uses UserId (lowercase 'd') due to upstream library inconsistency
 		return xrhid.Identity.ServiceAccount.UserId, nil
 	default:
-		return "", fmt.Errorf("unsupported identity type: %s (only User and ServiceAccount are supported)", xrhid.Identity.Type)
+		return "", fmt.Errorf("%w: unsupported identity type: %s (only User and ServiceAccount are supported)", ErrIdentityValidation, xrhid.Identity.Type)
 	}
 }
 
@@ -269,7 +269,7 @@ func GetWorkspaceID(ctx context.Context, orgID string, log *zap.SugaredLogger) (
 
 	workspaceID, err := globalManager.rbacClient.GetDefaultWorkspaceID(ctx, orgID)
 	if err != nil {
-		return "", fmt.Errorf("failed to get default workspace ID: %w", err)
+		return "", fmt.Errorf("%w: failed to get default workspace ID: %v", ErrServiceUnavailable, err)
 	}
 
 	log.Debugw("Found default workspace ID",

--- a/internal/common/kessel/authorization.go
+++ b/internal/common/kessel/authorization.go
@@ -123,7 +123,7 @@ func checkPermissionInternal(
 
 		response, err := globalManager.client.KesselInventoryService.CheckForUpdate(ctx, request, opts...)
 		if err != nil {
-			return false, fmt.Errorf("kessel check for update failed: %w", err)
+			return false, fmt.Errorf("%w: kessel check for update failed: %v", ErrServiceUnavailable, err)
 		}
 		allowed = response.GetAllowed() == kesselv2.Allowed_ALLOWED_TRUE
 
@@ -154,7 +154,7 @@ func checkPermissionInternal(
 
 		response, err := globalManager.client.KesselInventoryService.Check(ctx, request, opts...)
 		if err != nil {
-			return false, fmt.Errorf("kessel check failed: %w", err)
+			return false, fmt.Errorf("%w: kessel check failed: %v", ErrServiceUnavailable, err)
 		}
 		allowed = response.GetAllowed() == kesselv2.Allowed_ALLOWED_TRUE
 
@@ -374,17 +374,17 @@ func extractUserID(xrhid identity.XRHID) (string, error) {
 	switch xrhid.Identity.Type {
 	case "User":
 		if xrhid.Identity.User == nil || xrhid.Identity.User.UserID == "" {
-			return "", errors.New("user ID is empty")
+			return "", fmt.Errorf("%w: user ID is empty", ErrIdentityValidation)
 		}
 		return xrhid.Identity.User.UserID, nil
 	case "ServiceAccount":
 		if xrhid.Identity.ServiceAccount == nil || xrhid.Identity.ServiceAccount.UserId == "" {
-			return "", errors.New("service account user ID is empty")
+			return "", fmt.Errorf("%w: service account user ID is empty", ErrIdentityValidation)
 		}
 		// Note: ServiceAccount uses UserId (lowercase 'd') due to upstream library inconsistency
 		return xrhid.Identity.ServiceAccount.UserId, nil
 	default:
-		return "", fmt.Errorf("unsupported identity type: %s (only User and ServiceAccount are supported)", xrhid.Identity.Type)
+		return "", fmt.Errorf("%w: unsupported identity type: %s (only User and ServiceAccount are supported)", ErrIdentityValidation, xrhid.Identity.Type)
 	}
 }
 
@@ -408,7 +408,7 @@ func GetWorkspaceID(ctx context.Context, orgID string, log *zap.SugaredLogger) (
 	}
 
 	if err != nil {
-		return "", fmt.Errorf("failed to get default workspace ID: %w", err)
+		return "", fmt.Errorf("%w: failed to get default workspace ID: %v", ErrServiceUnavailable, err)
 	}
 
 	log.Debugw("Found default workspace ID",

--- a/internal/common/kessel/authorization_test.go
+++ b/internal/common/kessel/authorization_test.go
@@ -177,6 +177,7 @@ func TestCheckPermission_KesselError(t *testing.T) {
 	assert.Error(t, err)
 	assert.False(t, allowed)
 	assert.Contains(t, err.Error(), "Kessel check failed")
+	assert.True(t, IsServiceUnavailableError(err), "error should be ErrServiceUnavailable")
 }
 
 func TestCheckPermission_EmptyWorkspaceID(t *testing.T) {
@@ -239,6 +240,7 @@ func TestCheckPermission_UnsupportedIdentityType(t *testing.T) {
 	assert.False(t, allowed)
 	assert.Contains(t, err.Error(), "failed to extract user ID")
 	assert.Contains(t, err.Error(), "unsupported identity type: System")
+	assert.True(t, IsIdentityValidationError(err), "error should be ErrIdentityValidation")
 }
 
 func TestCheckPermission_EmptyUserID(t *testing.T) {
@@ -262,6 +264,7 @@ func TestCheckPermission_EmptyUserID(t *testing.T) {
 	assert.Error(t, err)
 	assert.False(t, allowed)
 	assert.Contains(t, err.Error(), "failed to extract user ID")
+	assert.True(t, IsIdentityValidationError(err), "error should be ErrIdentityValidation")
 	assert.Contains(t, err.Error(), "user ID is empty")
 }
 
@@ -285,6 +288,7 @@ func TestCheckPermission_NilUser(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.False(t, allowed)
+	assert.True(t, IsIdentityValidationError(err), "error should be ErrIdentityValidation")
 	assert.Contains(t, err.Error(), "failed to extract user ID")
 	assert.Contains(t, err.Error(), "user ID is empty")
 }
@@ -359,6 +363,7 @@ func TestCheckPermissionForUpdate_KesselError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.False(t, allowed)
+	assert.True(t, IsServiceUnavailableError(err), "error should be ErrServiceUnavailable")
 	assert.Contains(t, err.Error(), "Kessel check for update failed")
 }
 
@@ -400,6 +405,7 @@ func TestCheckPermissionForUpdate_UnsupportedIdentityType(t *testing.T) {
 	assert.False(t, allowed)
 	assert.Contains(t, err.Error(), "failed to extract user ID")
 	assert.Contains(t, err.Error(), "unsupported identity type: System")
+	assert.True(t, IsIdentityValidationError(err), "error should be ErrIdentityValidation")
 }
 
 func TestExtractUserID_User(t *testing.T) {
@@ -491,6 +497,7 @@ func TestGetWorkspaceID_RbacError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Empty(t, workspaceID)
 	assert.Contains(t, err.Error(), "failed to get default workspace ID")
+	assert.True(t, IsServiceUnavailableError(err), "error should be ErrServiceUnavailable")
 }
 
 func TestGetWorkspaceID_ClientNotInitialized(t *testing.T) {
@@ -614,6 +621,7 @@ func TestCheckApplicationPermissions_KesselError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, allowedApps)
+	assert.True(t, IsServiceUnavailableError(err), "error should be ErrServiceUnavailable")
 	assert.Contains(t, err.Error(), "structural failure")
 }
 

--- a/internal/common/kessel/authorization_test.go
+++ b/internal/common/kessel/authorization_test.go
@@ -204,6 +204,7 @@ func TestCheckPermission_KesselError(t *testing.T) {
 	assert.Error(t, err)
 	assert.False(t, allowed)
 	assert.Contains(t, err.Error(), "kessel check failed")
+	assert.True(t, IsServiceUnavailableError(err), "error should be ErrServiceUnavailable")
 }
 
 func TestCheckPermission_EmptyWorkspaceID(t *testing.T) {
@@ -266,6 +267,7 @@ func TestCheckPermission_UnsupportedIdentityType(t *testing.T) {
 	assert.False(t, allowed)
 	assert.Contains(t, err.Error(), "failed to extract user ID")
 	assert.Contains(t, err.Error(), "unsupported identity type: System")
+	assert.True(t, IsIdentityValidationError(err), "error should be ErrIdentityValidation")
 }
 
 func TestCheckPermission_EmptyUserID(t *testing.T) {
@@ -289,6 +291,7 @@ func TestCheckPermission_EmptyUserID(t *testing.T) {
 	assert.Error(t, err)
 	assert.False(t, allowed)
 	assert.Contains(t, err.Error(), "failed to extract user ID")
+	assert.True(t, IsIdentityValidationError(err), "error should be ErrIdentityValidation")
 	assert.Contains(t, err.Error(), "user ID is empty")
 }
 
@@ -312,6 +315,7 @@ func TestCheckPermission_NilUser(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.False(t, allowed)
+	assert.True(t, IsIdentityValidationError(err), "error should be ErrIdentityValidation")
 	assert.Contains(t, err.Error(), "failed to extract user ID")
 	assert.Contains(t, err.Error(), "user ID is empty")
 }
@@ -386,6 +390,7 @@ func TestCheckPermissionForUpdate_KesselError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.False(t, allowed)
+	assert.True(t, IsServiceUnavailableError(err), "error should be ErrServiceUnavailable")
 	assert.Contains(t, err.Error(), "kessel check for update failed")
 }
 
@@ -427,6 +432,7 @@ func TestCheckPermissionForUpdate_UnsupportedIdentityType(t *testing.T) {
 	assert.False(t, allowed)
 	assert.Contains(t, err.Error(), "failed to extract user ID")
 	assert.Contains(t, err.Error(), "unsupported identity type: System")
+	assert.True(t, IsIdentityValidationError(err), "error should be ErrIdentityValidation")
 }
 
 func TestExtractUserID_User(t *testing.T) {
@@ -518,6 +524,7 @@ func TestGetWorkspaceID_RbacError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Empty(t, workspaceID)
 	assert.Contains(t, err.Error(), "failed to get default workspace ID")
+	assert.True(t, IsServiceUnavailableError(err), "error should be ErrServiceUnavailable")
 }
 
 func TestGetWorkspaceID_ClientNotInitialized(t *testing.T) {
@@ -641,6 +648,7 @@ func TestCheckApplicationPermissions_KesselError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, allowedApps)
+	assert.True(t, IsServiceUnavailableError(err), "error should be ErrServiceUnavailable")
 	assert.Contains(t, err.Error(), "structural failure")
 }
 

--- a/internal/common/kessel/errors.go
+++ b/internal/common/kessel/errors.go
@@ -1,0 +1,27 @@
+// Package kessel provides Kessel inventory client integration for workspace-based authorization.
+//
+// Coded in collaboration with AI
+package kessel
+
+import "errors"
+
+// Error types for distinguishing between different failure modes
+var (
+	// ErrIdentityValidation indicates the identity header is malformed or missing required fields
+	// Should result in HTTP 400 Bad Request
+	ErrIdentityValidation = errors.New("identity validation failed")
+
+	// ErrServiceUnavailable indicates a downstream service (Kessel, RBAC) is unavailable
+	// Should result in HTTP 503 Service Unavailable
+	ErrServiceUnavailable = errors.New("authorization service unavailable")
+)
+
+// IsIdentityValidationError checks if an error is an identity validation error
+func IsIdentityValidationError(err error) bool {
+	return errors.Is(err, ErrIdentityValidation)
+}
+
+// IsServiceUnavailableError checks if an error is a service unavailable error
+func IsServiceUnavailableError(err error) bool {
+	return errors.Is(err, ErrServiceUnavailable)
+}


### PR DESCRIPTION
## What?
fix: improve Kessel authorization error handling and HTTP responses

### OVERVIEW
* Propagates typed Kessel authorization errors up through RBAC middleware to enable differentiated HTTP responses (400, 503, 500) based on identity validation and service availability issues.
* Updates Kessel service permission checks and workspace lookup to wrap failures with specific identity validation and service-unavailable error types.
* Adjusts Kessel- and RBAC-combined authorization modes so that validation mode falls back to RBAC on Kessel errors while enforcing modes surface Kessel failures appropriately.

## Why?
To more accurately reflect the error that occurred.

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
Authorization test updated accordingly

## Summary by Sourcery

Improve Kessel-based authorization error handling and HTTP responses in RBAC middleware.

New Features:
- Introduce typed Kessel authorization errors and helpers for detecting identity validation and service-unavailable failures.

Bug Fixes:
- Return appropriate HTTP status codes (400, 503, 500) based on typed Kessel identity validation and service availability errors instead of generic failures.

Enhancements:
- Propagate typed Kessel errors through authorization flows so Kessel-enforcing modes surface failures while validation modes fall back to RBAC results.
- Refine Kessel workspace lookup and permission checks to distinguish identity validation from service-unavailable conditions for better logging and instrumentation.

Tests:
- Extend Kessel authorization tests to assert identity-validation and service-unavailable error typing and behavior.