### PR TITLE
RHINENG-24177: add log guard to logging with method calls as arguments

### DIFF
--- a/event-streams/src/main/java/com/redhat/cloud/platform/playbook_dispatcher/RunEventTransform.java
+++ b/event-streams/src/main/java/com/redhat/cloud/platform/playbook_dispatcher/RunEventTransform.java
@@ -100,7 +100,9 @@ public class RunEventTransform<T extends ConnectRecord<T>> implements Transforma
 
         try {
             final String marshalledValue = objectMapper.writeValueAsString(event);
-            LOG.info("processed message; key: {}, event_type: {}, service: {}", newKey, event.getEventType(), event.getPayload().getService());
+            if (LOG.isInfoEnabled()) {
+                LOG.info("processed message; key: {}, event_type: {}, service: {}", newKey, event.getEventType(), event.getPayload().getService());
+            }
             return record.newRecord(this.topic, record.kafkaPartition(), null, newKey, null, marshalledValue, record.timestamp(), headers);
         } catch (JsonProcessingException e) {
             LOG.error("Error marshalling JSON", e);
@@ -172,7 +174,9 @@ public class RunEventTransform<T extends ConnectRecord<T>> implements Transforma
         try {
             labels = this.objectMapper.readValue(input.getString("labels"), Labels.class);
         } catch (JsonProcessingException e) {
-            LOG.warn("Ignoring message labels due to parsing error, id={}, labels={}", input.getString("id"), input.getString("labels"));
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("Ignoring message labels due to parsing error, id={}, labels={}", input.getString("id"), input.getString("labels"));
+            }
             labels = new Labels();
         }
 

--- a/event-streams/src/main/java/com/redhat/cloud/platform/playbook_dispatcher/RunHostEventTransform.java
+++ b/event-streams/src/main/java/com/redhat/cloud/platform/playbook_dispatcher/RunHostEventTransform.java
@@ -95,7 +95,9 @@ public class RunHostEventTransform<T extends ConnectRecord<T>> implements Transf
 
         try {
             final String marshalledValue = objectMapper.writeValueAsString(event);
-            LOG.info("processed message; key: {}, event_type: {}", newKey, event.getEventType());
+            if (LOG.isInfoEnabled()) {
+                LOG.info("processed message; key: {}, event_type: {}", newKey, event.getEventType());
+            }
             return record.newRecord(this.topic, record.kafkaPartition(), null, newKey, null, marshalledValue, record.timestamp(), headers);
         } catch (JsonProcessingException e) {
             LOG.error("Error marshalling JSON", e);


### PR DESCRIPTION
## What?
refactor: guard playbook dispatcher logging with log-level checks

### OVERVIEW
* Added log-level checks around info and warn log statements in run event and run host event transforms to avoid unnecessary logging overhead.

## Summary by Sourcery

Add log-level guards around playbook dispatcher logging to avoid unnecessary evaluation when info and warn logs are disabled.

Enhancements:
- Guard playbook dispatcher info and warn log statements with log-level checks in run and host event transforms.
- Relax static analysis by excluding the GuardLogStatement rule in the PMD configuration for tests.