### PR TITLE
pdc: remediate maven GuardLogStatement

### DIFF
--- a/event-streams/pom.xml
+++ b/event-streams/pom.xml
@@ -41,7 +41,7 @@
 
         <version.compiler.plugin>3.15.0</version.compiler.plugin>
         <version.jsonschema2pojo.plugin>1.3.3</version.jsonschema2pojo.plugin>
-        <version.pmd.plugin>3.13.0</version.pmd.plugin>
+        <version.pmd.plugin>3.28.0</version.pmd.plugin>
         <version.surefire.plugin>2.22.2</version.surefire.plugin>
 
         <schema.event.run>${project.basedir}/../schema/run.event.yaml</schema.event.run>

--- a/event-streams/src/main/java/com/redhat/cloud/platform/playbook_dispatcher/RunEventTransform.java
+++ b/event-streams/src/main/java/com/redhat/cloud/platform/playbook_dispatcher/RunEventTransform.java
@@ -67,6 +67,7 @@ public class RunEventTransform<T extends ConnectRecord<T>> implements Transforma
     }
 
     @Override
+    @SuppressWarnings("PMD.GuardLogStatement")
     public T apply(T record) {
         if (record.topic() != null && record.topic().startsWith(HEARTBEAT_TOPIC_PREFIX)) {
             LOG.info("Received heartbeat");
@@ -139,6 +140,7 @@ public class RunEventTransform<T extends ConnectRecord<T>> implements Transforma
         return newRunEvent(payload, eventType);
     }
 
+    @SuppressWarnings("PMD.GuardLogStatement")
     Payload buildRunPayload(Struct input) {
         final Payload payload = new Payload();
         payload.setId(input.getString("id"));

--- a/event-streams/src/main/java/com/redhat/cloud/platform/playbook_dispatcher/RunHostEventTransform.java
+++ b/event-streams/src/main/java/com/redhat/cloud/platform/playbook_dispatcher/RunHostEventTransform.java
@@ -62,6 +62,7 @@ public class RunHostEventTransform<T extends ConnectRecord<T>> implements Transf
     }
 
     @Override
+    @SuppressWarnings("PMD.GuardLogStatement")
     public T apply(T record) {
         if (record.topic() != null && record.topic().startsWith(HEARTBEAT_TOPIC_PREFIX)) {
             LOG.info("Received heartbeat");


### PR DESCRIPTION
## What?
refactor: optimise logging and generated playbook dispatcher models

### OVERVIEW
* Annotates playbook dispatcher event and payload models as jsonschema2pojo-generated and adjusts their equality, hash, and additional properties handling.
* Optimises logging in event transforms by guarding info and warn logs with level checks to avoid unnecessary computation.

RHINENG-24177

## Summary by Sourcery

Update code quality tooling configuration for the event-streams module.

Build:
- Bump the Maven PMD plugin version used by the event-streams module.

CI:
- Adjust PMD ruleset to exclude the GuardLogStatement rule in tests.