### PR TITLE
Fix PR 624: dependency maven-wrapper

### DIFF
--- a/event-streams/.mvn/wrapper/maven-wrapper.properties
+++ b/event-streams/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar
+wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/event-streams/.mvn/wrapper/maven-wrapper.properties
+++ b/event-streams/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar


### PR DESCRIPTION
## What?
chore(deps): update maven wrapper and gommon dependency versions

### OVERVIEW
* Updates the Maven wrapper to use the newer official Apache Maven Wrapper artifact.
* Bumps the indirect Go dependency github.com/labstack/gommon from v0.4.2 to v0.5.0.

Fixes: RHINENG-25946

## Summary by Sourcery

Build:
- Switch Maven wrapper to use the official Apache Maven Wrapper artifact version 3.3.4.