### PR TITLE
Pr 764

### DIFF
--- a/event-streams/Dockerfile
+++ b/event-streams/Dockerfile
@@ -26,7 +26,7 @@ RUN ./mvnw -Dschema.event.run=/src/run.event.yaml -Dschema.event.run.host=/src/r
 
 
 # https://access.redhat.com/documentation/en-us/red_hat_amq/2021.q3/html-single/deploying_and_upgrading_amq_streams_on_openshift/index#creating-new-image-from-base-str
-FROM registry.redhat.io/amq-streams/kafka-39-rhel9:2.9.3-28
+FROM registry.redhat.io/amq-streams/kafka-39-rhel9:3.0.1-10
 ARG BUILD_COMMIT=unknown
 
 ENV CONNECT_PLUGIN_PATH=/opt/kafka/plugins \

--- a/event-streams/Dockerfile
+++ b/event-streams/Dockerfile
@@ -26,7 +26,7 @@ RUN ./mvnw -Dschema.event.run=/src/run.event.yaml -Dschema.event.run.host=/src/r
 
 
 # https://access.redhat.com/documentation/en-us/red_hat_amq/2021.q3/html-single/deploying_and_upgrading_amq_streams_on_openshift/index#creating-new-image-from-base-str
-FROM registry.redhat.io/amq-streams/kafka-39-rhel9:3.0.1-10
+FROM registry.redhat.io/amq-streams/kafka-41-rhel9:3.1.0-16
 ARG BUILD_COMMIT=unknown
 
 ENV CONNECT_PLUGIN_PATH=/opt/kafka/plugins \
@@ -46,7 +46,7 @@ COPY --from=builder /deps/plugins $CONNECT_PLUGIN_PATH
 
 COPY --from=builder /deps/libs $CONNECT_LIB_PATH
 
-COPY event-streams/log4j.properties /opt/kafka/custom-config
+COPY event-streams/log4j2.properties /opt/kafka/custom-config
 RUN rm -rf /opt/kafka-exporter
 
 USER 1001

--- a/event-streams/log4j.properties
+++ b/event-streams/log4j.properties
@@ -1,8 +1,0 @@
-# Root logger option
-log4j.rootLogger=INFO, stdout
-
-# Direct log messages to stdout
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%d{ISO8601}] %p %m (%c{1}:%L)%n

--- a/event-streams/pom.xml
+++ b/event-streams/pom.xml
@@ -32,12 +32,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
 
         <version.jackson>2.21.2</version.jackson>
         <version.jackson.databind>2.21.2</version.jackson.databind>
         <version.junit>4.13.2</version.junit>
-        <version.kafka>4.2.0</version.kafka>
+        <version.kafka>4.1.0</version.kafka>
 
         <version.compiler.plugin>3.15.0</version.compiler.plugin>
         <version.jsonschema2pojo.plugin>1.3.3</version.jsonschema2pojo.plugin>


### PR DESCRIPTION
## What?
chore: update kessel inventory mocks and dependency versions

### OVERVIEW
* Extend the Kessel inventory service test mock with additional check and streaming subject methods to align with the latest API.
* Bump Go dependencies, including the inventory API and several indirect libraries, and clean up unused modules.
* Update the event-streams module build tooling (Maven wrapper), Jackson versions, Kafka client version, and Kafka base image used in the Dockerfile.