### PR TITLE
Fix PR 760

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/labstack/echo/v4 v4.15.1
 	github.com/mec07/cloudwatchwriter v0.2.6
 	github.com/oapi-codegen/echo-middleware v1.0.2
-	github.com/oapi-codegen/runtime v1.2.0
+	github.com/oapi-codegen/runtime v1.4.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.39.1
 	github.com/project-kessel/inventory-api v0.0.0-20260422134415-ed4661018b7f

--- a/go.sum
+++ b/go.sum
@@ -528,8 +528,8 @@ github.com/oapi-codegen/echo-middleware v1.0.2 h1:oNBqiE7jd/9bfGNk/bpbX2nqWrtPc+
 github.com/oapi-codegen/echo-middleware v1.0.2/go.mod h1:5J6MFcGqrpWLXpbKGZtRPZViLIHyyyUHlkqg6dT2R4E=
 github.com/oapi-codegen/oapi-codegen/v2 v2.6.0 h1:4i+F2cvwBFZeplxCssNdLy3MhNzUD87mI3HnayHZkAU=
 github.com/oapi-codegen/oapi-codegen/v2 v2.6.0/go.mod h1:eWHeJSohQJIINJZzzQriVynfGsnlQVh0UkN2UYYcw4Q=
-github.com/oapi-codegen/runtime v1.2.0 h1:RvKc1CVS1QeKSNzO97FBQbSMZyQ8s6rZd+LpmzwHMP4=
-github.com/oapi-codegen/runtime v1.2.0/go.mod h1:Y7ZhmmlE8ikZOmuHRRndiIm7nf3xcVv+YMweKgG1DT0=
+github.com/oapi-codegen/runtime v1.4.0 h1:KLOSFOp7UzkbS7Cs1ms6NBEKYr0WmH2wZG0KKbd2er4=
+github.com/oapi-codegen/runtime v1.4.0/go.mod h1:5sw5fxCDmnOzKNYmkVNF8d34kyUeejJEY8HNT2WaPec=
 github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 h1:G7ERwszslrBzRxj//JalHPu/3yz+De2J+4aLtSRlHiY=
 github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037/go.mod h1:2bpvgLBZEtENV5scfDFEtB/5+1M4hkQhDQrccEJ/qGw=
 github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 h1:bQx3WeLcUWy+RletIKwUIt4x3t8n2SxavmoclizMb8c=

--- a/internal/api/controllers/private/runHostsListV2.go
+++ b/internal/api/controllers/private/runHostsListV2.go
@@ -57,21 +57,21 @@ func (apii *controllers) ApiInternalV2RunHostsList(ctx echo.Context, params ApiI
 			}
 		}
 
-		if runFilters := middleware.GetDeepObject(ctx, "filter", "run"); len(runFilters) > 0 {
-			if id, ok := runFilters["id"]; ok {
-				queryBuilder.Where("run_hosts.run_id = ?", id)
+		if params.Filter.Run != nil {
+			if params.Filter.Run.Id != nil {
+				queryBuilder.Where("run_hosts.run_id = ?", *params.Filter.Run.Id)
 			}
 
-			if service, ok := runFilters["service"]; ok {
-				queryBuilder.Where("runs.service = ?", service)
+			if params.Filter.Run.Service != nil {
+				queryBuilder.Where("runs.service = ?", *params.Filter.Run.Service)
 			}
-		}
 
-		if labelFilters := middleware.GetDeepObject(ctx, "filter", "run", "labels"); len(labelFilters) > 0 {
-			queryBuilder, err = addLabelFilterToQueryAsWhereClause(queryBuilder, labelFilters)
-			if err != nil {
-				instrumentation.PlaybookApiRequestError(ctx, err)
-				return echo.NewHTTPError(http.StatusInternalServerError, "Unable to handle labels query!")
+			if params.Filter.Run.Labels != nil {
+				queryBuilder, err = addLabelFilterToQueryAsWhereClause(queryBuilder, *params.Filter.Run.Labels)
+				if err != nil {
+					instrumentation.PlaybookApiRequestError(ctx, err)
+					return echo.NewHTTPError(http.StatusInternalServerError, "Unable to handle labels query!")
+				}
 			}
 		}
 
@@ -193,10 +193,14 @@ func parseFields(input map[string][]string, key string, knownFields map[string]s
 
 	for _, value := range selectedFields {
 		for _, field := range strings.Split(value, ",") {
-			if _, ok := knownFields[field]; ok {
-				result = append(result, field)
+			trimmed := strings.TrimSpace(field)
+			if trimmed == "" {
+				continue
+			}
+			if _, ok := knownFields[trimmed]; ok {
+				result = append(result, trimmed)
 			} else {
-				return nil, fmt.Errorf("unknown field: %s", field)
+				return nil, fmt.Errorf("unknown field: %s", trimmed)
 			}
 		}
 	}
@@ -260,15 +264,7 @@ func inventoryLink(inventoryID *uuid.UUID) *string {
 	return &link
 }
 
-func addLabelFilterToQueryAsWhereClause(queryBuilder *gorm.DB, labelFilters map[string][]string) (*gorm.DB, error) {
-	labels := make(map[string]string)
-
-	for key, values := range labelFilters {
-		for _, value := range values {
-			labels[key] = value
-		}
-	}
-
+func addLabelFilterToQueryAsWhereClause(queryBuilder *gorm.DB, labels map[string]string) (*gorm.DB, error) {
 	if len(labels) == 0 {
 		return queryBuilder, nil
 	}

--- a/internal/api/controllers/public/runHostsList.go
+++ b/internal/api/controllers/public/runHostsList.go
@@ -51,21 +51,21 @@ func (this *controllers) ApiRunHostsList(ctx echo.Context, params ApiRunHostsLis
 			}
 		}
 
-		if runFilters := middleware.GetDeepObject(ctx, "filter", "run"); len(runFilters) > 0 {
-			if id, ok := runFilters["id"]; ok {
-				queryBuilder.Where("run_hosts.run_id = ?", id)
+		if params.Filter.Run != nil {
+			if params.Filter.Run.Id != nil {
+				queryBuilder.Where("run_hosts.run_id = ?", *params.Filter.Run.Id)
 			}
 
-			if service, ok := runFilters["service"]; ok {
-				queryBuilder.Where("runs.service = ?", service)
+			if params.Filter.Run.Service != nil {
+				queryBuilder.Where("runs.service = ?", *params.Filter.Run.Service)
 			}
-		}
 
-		if labelFilters := middleware.GetDeepObject(ctx, "filter", "run", "labels"); len(labelFilters) > 0 {
-			queryBuilder, err = addLabelFilterToQueryAsWhereClause(queryBuilder, labelFilters)
-			if err != nil {
-				instrumentation.PlaybookApiRequestError(ctx, err)
-				return echo.NewHTTPError(http.StatusInternalServerError, "Unable to handle labels query!")
+			if params.Filter.Run.Labels != nil {
+				queryBuilder, err = addLabelFilterToQueryAsWhereClause(queryBuilder, *params.Filter.Run.Labels)
+				if err != nil {
+					instrumentation.PlaybookApiRequestError(ctx, err)
+					return echo.NewHTTPError(http.StatusInternalServerError, "Unable to handle labels query!")
+				}
 			}
 		}
 

--- a/internal/api/controllers/public/runsList.go
+++ b/internal/api/controllers/public/runsList.go
@@ -96,8 +96,8 @@ func (this *controllers) ApiRunsList(ctx echo.Context, params ApiRunsListParams)
 		}
 	}
 
-	if labelFilters := middleware.GetDeepObject(ctx, "filter", "labels"); len(labelFilters) > 0 {
-		queryBuilder, err = addLabelFilterToQueryAsWhereClause(queryBuilder, labelFilters)
+	if params.Filter != nil && params.Filter.Labels != nil {
+		queryBuilder, err = addLabelFilterToQueryAsWhereClause(queryBuilder, *params.Filter.Labels)
 		if err != nil {
 			instrumentation.PlaybookApiRequestError(ctx, err)
 			return echo.NewHTTPError(http.StatusInternalServerError, "Unable to handle labels query!")
@@ -143,21 +143,7 @@ func (this *controllers) ApiRunsList(ctx echo.Context, params ApiRunsListParams)
 	})
 }
 
-func addLabelFilterToQueryAsWhereClause(queryBuilder *gorm.DB, labelFilters map[string][]string) (*gorm.DB, error) {
-	labels := make(map[string]string)
-
-	for key, values := range labelFilters {
-		// The inner for loop seems kind of odd.  The labels are basically a
-		// hash map. As a result, you cannot have duplicate keys.  However, it
-		// seems to be possible to pass in multiple values for the same key in
-		// the web request url.  With the approach below, we will take the last
-		// value for duplicate keys that are passed in on the url.
-		// example:  api/playbook-dispatcher/v1/runs?filter[labels][bar]=5678&filter[labels][bar]=1234"
-		for _, value := range values {
-			labels[key] = value
-		}
-	}
-
+func addLabelFilterToQueryAsWhereClause(queryBuilder *gorm.DB, labels map[string]string) (*gorm.DB, error) {
 	if len(labels) == 0 {
 		return queryBuilder, nil
 	}

--- a/internal/api/main.go
+++ b/internal/api/main.go
@@ -125,7 +125,7 @@ func Start(
 
 	privateController := private.CreateController(db, cloudConnectorClient, inventoryConnectorClient, sourcesConnectorClient, cfg, translator)
 	internal := server.Group("/internal")
-	internal.GET("/v2/run_hosts", privateController.ApiInternalV2RunHostsList, middleware.CheckPskAuth(authConfig), echo.WrapMiddleware(identity.EnforceIdentity), middleware.ExtractHeaders(constants.HeaderIdentity), middleware.CaptureQueryString(), middleware.Hack("filter", "labels"), middleware.Hack("filter", "run"), middleware.Hack("filter", "run", "labels"), middleware.Hack("fields"), oapiMiddleware.OapiRequestValidator(privateSpec))
+	internal.GET("/v2/run_hosts", privateController.ApiInternalV2RunHostsList, middleware.CheckPskAuth(authConfig), echo.WrapMiddleware(identity.EnforceIdentity), middleware.ExtractHeaders(constants.HeaderIdentity), middleware.CaptureQueryString(), middleware.Hack("fields"), oapiMiddleware.OapiRequestValidator(privateSpec))
 	internal.Use(oapiMiddleware.OapiRequestValidator(privateSpec))
 	// Authorization header not required for GET /internal/version
 	internal.GET("/version", privateController.ApiInternalVersion)
@@ -142,9 +142,6 @@ func Start(
 	public.Use(echo.WrapMiddleware(identity.EnforceIdentity))
 	public.Use(echo.WrapMiddleware(middleware.EnforceIdentityType))
 	public.Use(middleware.CaptureQueryString())
-	public.Use(middleware.Hack("filter", "labels"))
-	public.Use(middleware.Hack("filter", "run"))
-	public.Use(middleware.Hack("filter", "run", "labels"))
 	public.Use(middleware.Hack("fields"))
 	public.Use(oapiMiddleware.OapiRequestValidator(publicSpec))
 	public.Use(middleware.ExtractHeaders(constants.HeaderIdentity))


### PR DESCRIPTION
Fixes: RHINENG-25995

## Summary by Sourcery

Switch run host and runs list APIs to use typed request parameters for run and label filters and simplify label filtering helpers to accept flat label maps.

Enhancements:
- Simplify label filter helper functions to operate on flat label maps instead of URL-derived deep objects.

Build:
- Bump Go dependency github.com/oapi-codegen/runtime from v1.2.0 to v1.4.0.