### PR TITLE
add security workflows

### DIFF
--- a/.github/workflows/security-pd.yml
+++ b/.github/workflows/security-pd.yml
@@ -1,0 +1,43 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# The default values used in the docker build commands are the root
+# directory '.' and the dockerfile name of 'Dockerfile'. If there is 
+# a need to change these do so in your local workflow template (this file) and
+# change them there. HINT: Look at the bottom of this file.
+
+# This workflow checks out code, builds an image, performs a container image
+# vulnerability scan with Anchore's Grype tool, and generates an
+# SBOM via Anchore's Syft tool
+
+# For more information on Anchore's container image scanning tool Grype, see
+# https://github.com/anchore/grype
+
+# For more information about the Anchore SBOM tool, Syft, see
+# https://github.com/anchore/syft
+
+name: ConsoleDot Platform Security Scan
+
+on:
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main", "master" ]
+
+jobs:
+  PlatSec-Security-Workflow-Playbook-Dispatcher:
+    uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@master
+    ## The optional parameters below are used if you are using something other than the
+    ## the defaults of root '.' for the path and 'Dockerfile' for the Dockerfile name.
+    ## Additionally, if you have a Dockerfile you use as your BASE_IMG or you need to
+    ## use '--build-arg', those can be define below as well.
+
+    with:
+      app_name: 'playbook-dispatcher'
+      dockerfile_path: '.'
+      dockerfile_name: 'Dockerfile'
+      severity_fail_cutoff: high
+      fail_on_vulns: true


### PR DESCRIPTION
## What?
chore(ci): add platform security scan workflow for container image

OVERVIEW
Introduce a GitHub Actions workflow that runs the Red Hat Platform Security reusable scan on pushes and pull requests to main/master, scanning the playbook-dispatcher Docker image and failing the build on high-severity vulnerabilities.

Fixes: RHINENG-26134

## Summary by Sourcery

CI:
- Introduce a reusable Red Hat Insights platform security scan workflow that builds and scans the playbook-dispatcher Docker image, failing on high-severity vulnerabilities.