### PR TITLE
update golang to 1.25.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module playbook-dispatcher
 
-go 1.25.7
+go 1.25.9
 
 require (
 	github.com/RedHatInsights/tenant-utils v1.0.0


### PR DESCRIPTION
## What?
Updating golang to 1.25.9

Fixes: RHINENG-26288

## Summary by Sourcery

Build:
- Update the Go language version requirement in go.mod from 1.25.7 to 1.25.9.