### PR TITLE
Remove sre-testing-templates sub module and its associated .gitmodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "sre-testing-templates"]
-	path = sre-testing-templates
-	url = https://github.com/RedHatInsights/sre-testing-templates.git


### PR DESCRIPTION
## What?
To implement e2e test pipelines for the playbook dispatcher I added sre-testing-templates a sub module to the repo. This caused issues with grype vulnerability checks. I am going to remove the sub module and add the needed templates as files in the repo. 

https://redhat.atlassian.net/browse/RHINENG-26361

## Why?
This caused issues with grype vulnerability checks. 

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Remove the sre-testing-templates git submodule and its associated .gitmodules configuration to simplify the repository layout and avoid related tooling issues.

Chores:
- Delete the sre-testing-templates submodule directory from the repository.
- Remove the .gitmodules file that configured the sre-testing-templates submodule.