### PR TITLE
Add job and cronjob templates for e2e tests to the PD repo

### DIFF
--- a/deploy/iqe-cronjob-template.yaml
+++ b/deploy/iqe-cronjob-template.yaml
@@ -59,7 +59,7 @@ objects:
                     - name: IQE_NETLOG
                       value: '${IQE_NETLOG}'
                     - name: IQE_PLUGINS 
-                      value: 'playbook-dispatcher'
+                      value: '${IQE_PLUGINS}'
                     - name: IQE_MARKER_EXPRESSION
                       value: '${IQE_MARKER_EXPRESSION}'
                     - name: IQE_FILTER_EXPRESSION
@@ -146,10 +146,6 @@ objects:
                     requests:
                       cpu: '${SEL_REQUESTS_CPU}'
                       memory: '${SEL_REQUESTS_MEMORY}'
-                  volumeMounts:
-                    - name: sel-shm
-                      mountPath: /dev/shm
-                  restartPolicy: Always # im a sidecar 🤡
 parameters:
   - name: IMAGE_TAG
     value: ''
@@ -166,7 +162,7 @@ parameters:
     description: container image path for the iqe plugin
     value: quay.io/cloudservices/iqe-tests
   - name: IQE_PLUGINS
-    value: 'platbook-dispatcher'
+    value: ''
     required: true
   - name: IQE_IMAGE_TAG
     value: ''

--- a/deploy/iqe-cronjob-template.yaml
+++ b/deploy/iqe-cronjob-template.yaml
@@ -1,0 +1,245 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: 'playbook-dispatcher-e2e-tests-schedule'
+objects:
+  - apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      name: 'playbook-dispatcher-e2e-tests-schedule'
+      annotations:
+        ignore-check.kube-linter.io/no-liveness-probe: probes not required on Job pods
+        ignore-check.kube-linter.io/no-readiness-probe: probes not required on Job pods
+    spec:
+      schedule: '${CRON_SCHEDULE}'
+      successfulJobsHistoryLimit: 3
+      failedJobsHistoryLimit: 8
+      jobTemplate:
+        spec:
+          activeDeadlineSeconds: ${{PIPELINE_TIMEOUT}}
+          backoffLimit: 0
+          template:
+            metadata:
+              labels:
+                iqe-metrics: "true"
+            spec:
+              imagePullSecrets:
+                - name: quay-cloudservices-pull
+              restartPolicy: Never
+              volumes:
+                - name: sel-shm
+                  emptyDir:
+                    medium: Memory
+                - name: insights-qa-private-key
+                  secret:
+                    secretName: insights-qa-private-key
+                    defaultMode: 384 # Means 0600
+                    optional: true
+              containers:
+                - name: 'iqe-runner-${NAME_STUB}-${IMAGE_TAG}-${UID}'
+                  image: '${IQE_IMAGE}:${IQE_IMAGE_TAG}'
+                  imagePullPolicy: Always
+                  args:
+                    - run
+                  envFrom:
+                    - secretRef:
+                        name: iqe-ibutsu-token
+                        optional: true
+                    - configMapRef:
+                        name: '${CONFIGMAP_NAME}'
+                  env:
+                    - name: ENV_FOR_DYNACONF
+                      value: '${ENV_FOR_DYNACONF}'
+                    - name: DYNACONF_MAIN__use_beta
+                      value: '${USE_BETA}'
+                    - name: IBUTSU_SOURCE
+                      value: 'playbook-dispatcher-${IMAGE_TAG}-${UID}'
+                    - name: IQE_BROWSERLOG
+                      value: '${IQE_BROWSERLOG}'
+                    - name: IQE_NETLOG
+                      value: '${IQE_NETLOG}'
+                    - name: IQE_PLUGINS 
+                      value: 'playbook-dispatcher'
+                    - name: IQE_MARKER_EXPRESSION
+                      value: '${IQE_MARKER_EXPRESSION}'
+                    - name: IQE_FILTER_EXPRESSION
+                      value: '${IQE_FILTER_EXPRESSION}'
+                    - name: IQE_LOG_LEVEL
+                      value: '${IQE_LOG_LEVEL}'
+                    - name: IQE_REQUIREMENTS
+                      value: '${IQE_REQUIREMENTS}'
+                    - name: IQE_REQUIREMENTS_PRIORITY
+                      value: '${IQE_REQUIREMENTS_PRIORITY}'
+                    - name: IQE_TEST_IMPORTANCE
+                      value: '${IQE_TEST_IMPORTANCE}'
+                    - name: IQE_PARALLEL_ENABLED
+                      value: '${IQE_PARALLEL_ENABLED}'
+                    - name: IQE_PARALLEL_WORKER_COUNT
+                      value: '${IQE_PARALLEL_WORKER_COUNT}'
+                    - name: IQE_PROMETHEUS_ENABLED
+                      value: '${IQE_PROMETHEUS_ENABLED}'
+                    - name: DYNACONF_IQE_VAULT_LOADER_ENABLED
+                      value: 'true'
+                    - name: DYNACONF_IQE_VAULT_VERIFY
+                      value: 'true'
+                    - name: DYNACONF_DEFAULT_USER
+                      value: '${DYNACONF_DEFAULT_USER}'
+                    - name: DYNACONF_IQE_VAULT_URL
+                      valueFrom:
+                        secretKeyRef:
+                          key: url
+                          name: iqe-vault
+                          optional: true
+                    - name: DYNACONF_IQE_VAULT_MOUNT_POINT
+                      valueFrom:
+                        secretKeyRef:
+                          key: mountPoint
+                          name: iqe-vault
+                          optional: true
+                    - name: DYNACONF_IQE_VAULT_ROLE_ID
+                      valueFrom:
+                        secretKeyRef:
+                          key: roleId
+                          name: iqe-vault
+                          optional: true
+                    - name: DYNACONF_IQE_VAULT_SECRET_ID
+                      valueFrom:
+                        secretKeyRef:
+                          key: secretId
+                          name: iqe-vault
+                          optional: true
+                    - name: PYTEST_ADDOPTS
+                      value: '${PYTEST_ADDOPTS}'
+                    - name: IQE_ENV_VARS
+                      value: '${IQE_ENV_VARS}'
+                  ports:
+                    - containerPort: 9091
+                      name: metrics
+                      protocol: TCP
+                  resources:
+                    limits:
+                      cpu: '${IQE_LIMITS_CPU}'
+                      memory: '${IQE_LIMITS_MEMORY}'
+                    requests:
+                      cpu: '${IQE_REQUESTS_CPU}'
+                      memory: '${IQE_REQUESTS_MEMORY}'
+                  volumeMounts:
+                    - name: insights-qa-private-key
+                      mountPath: /iqe_venv/.ssh
+                      readOnly: true
+                  terminationMessagePath: /dev/termination-log
+                  terminationMessagePolicy: File
+              initContainers:
+                - name: 'iqe-sel-${IMAGE_TAG}-${UID}'
+                  image: '${IQE_SEL_IMAGE}'
+                  env:
+                    - name: _JAVA_OPTIONS
+                      value: '${SELENIUM_JAVA_OPTS}'
+                    - name: SE_NODE_MAX_SESSIONS
+                      value: '${SE_NODE_MAX_SESSIONS}'
+                    - name: SE_NODE_OVERRIDE_MAX_SESSIONS
+                      value: '${SE_NODE_OVERRIDE_MAX_SESSIONS}'
+                  resources:
+                    limits:
+                      cpu: '${SEL_LIMITS_CPU}'
+                      memory: '${SEL_LIMITS_MEMORY}'
+                    requests:
+                      cpu: '${SEL_REQUESTS_CPU}'
+                      memory: '${SEL_REQUESTS_MEMORY}'
+                  volumeMounts:
+                    - name: sel-shm
+                      mountPath: /dev/shm
+                  restartPolicy: Always # im a sidecar 🤡
+parameters:
+  - name: IMAGE_TAG
+    value: ''
+    required: true
+  - name: UID
+    description: Unique job name suffix
+    generate: expression
+    from: '[a-z0-9]{6}'
+  - name: CRON_SCHEDULE
+    description: Schedule for cron job
+    value: '0 3 * * *' # 3AM everyday
+    required: true
+  - name: IQE_IMAGE
+    description: container image path for the iqe plugin
+    value: quay.io/cloudservices/iqe-tests
+  - name: IQE_PLUGINS
+    value: 'platbook-dispatcher'
+    required: true
+  - name: IQE_IMAGE_TAG
+    value: ''
+  - name: ENV_FOR_DYNACONF
+    value: ''
+  - name: USE_BETA
+    value: 'true'
+  - name: IQE_MARKER_EXPRESSION
+    value: ''
+  - name: IQE_FILTER_EXPRESSION
+    value: ''
+  - name: IQE_LOG_LEVEL
+    value: info
+  - name: IQE_REQUIREMENTS
+    value: ''
+  - name: IQE_REQUIREMENTS_PRIORITY
+    value: ''
+  - name: IQE_TEST_IMPORTANCE
+    value: ''
+  - name: IQE_SEL_IMAGE
+    value: 'quay.io/app-sre/selenium-standalone-chrome:136.0-20250828'
+  - name: IQE_BROWSERLOG
+    value: '1'
+  - name: IQE_NETLOG
+    value: '1'
+  - name: NAME_STUB
+    value: ''
+  - name: SELENIUM_JAVA_OPTS
+    value: ''
+  - name: SE_NODE_MAX_SESSIONS
+    value: '2'
+  - name: SE_NODE_OVERRIDE_MAX_SESSIONS
+    value: 'true'
+  - name: IQE_LIMITS_CPU
+    value: '1.5'
+  - name: IQE_LIMITS_MEMORY
+    value: 2.5Gi
+  - name: IQE_REQUESTS_CPU
+    value: 250m
+  - name: IQE_REQUESTS_MEMORY
+    value: 2Gi
+  - name: SEL_LIMITS_CPU
+    value: 500m
+  - name: SEL_LIMITS_MEMORY
+    value: 2Gi
+  - name: SEL_REQUESTS_CPU
+    value: 100m
+  - name: SEL_REQUESTS_MEMORY
+    value: 256Mi
+  - name: DYNACONF_DEFAULT_USER
+    value: 'playbook_dispatcher_1'
+  - name: IQE_RP_ARGS
+    value: 'true'
+  - name: RP_LAUNCH_DESCRIPTION
+    value: ''
+  - name: RP_LAUNCH
+    value: ''
+  - name: RP_PROJECT
+    value: ''
+  - name: IQE_ENV_VARS
+    value: '' # KEY1=VALUE1,KEY2=VALUE2,
+  - name: CONFIGMAP_NAME
+    value: 'ibutsu-config'
+  # When IQE_PARALLEL_ENABLED is false, IQE_PARALLEL_WORKER_COUNT is ignored.
+  - name: IQE_PARALLEL_ENABLED
+    value: 'false'
+  - name: IQE_PARALLEL_WORKER_COUNT
+    value: '0'
+  - name: IQE_PROMETHEUS_ENABLED
+    value: 'true'
+  - name: PIPELINE_TIMEOUT
+    description: Max pipeline runtime in seconds before termination (default 6h)
+    value: '21600'
+  - name: PYTEST_ADDOPTS
+    value: ''
+    description: Example value "--foobar1 --foobar2=value"

--- a/deploy/iqe-job-template.yaml
+++ b/deploy/iqe-job-template.yaml
@@ -202,7 +202,7 @@ parameters:
   - name: SEL_REQUESTS_MEMORY
     value: 256Mi
   - name: DYNACONF_DEFAULT_USER
-    value: 'insights_qa'
+    value: 'playbook_dispatcher_1'
   - name: IQE_RP_ARGS
     value: 'true'
   - name: RP_LAUNCH_DESCRIPTION

--- a/deploy/iqe-job-template.yaml
+++ b/deploy/iqe-job-template.yaml
@@ -135,10 +135,6 @@ objects:
                 requests:
                   cpu: '${SEL_REQUESTS_CPU}'
                   memory: '${SEL_REQUESTS_MEMORY}'
-              volumeMounts:
-                - name: sel-shm
-                  mountPath: /dev/shm
-              restartPolicy: Always # im a sidecar 🤡
 parameters:
   - name: IMAGE_TAG
     value: ''
@@ -151,7 +147,7 @@ parameters:
     description: container image path for the iqe plugin
     value: quay.io/cloudservices/iqe-tests
   - name: IQE_PLUGINS
-    value: 'playbook-dispatcher'
+    value: '${IQE_PLUGINS}'
     required: true
   - name: IQE_IMAGE_TAG
     value: ''

--- a/deploy/iqe-job-template.yaml
+++ b/deploy/iqe-job-template.yaml
@@ -1,0 +1,225 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: 'playbook-dispatcher-e2e-tests-job'
+objects:
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: 'playbook-dispatcher-e2e-tests-job'
+      annotations:
+        ignore-check.kube-linter.io/no-liveness-probe: probes not required on Job pods
+        ignore-check.kube-linter.io/no-readiness-probe: probes not required on Job pods
+    spec:
+      activeDeadlineSeconds: ${{PIPELINE_TIMEOUT}}
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            iqe-metrics: "true"
+        spec:
+          imagePullSecrets:
+            - name: quay-cloudservices-pull
+          restartPolicy: Never
+          volumes:
+            - name: sel-shm
+              emptyDir:
+                medium: Memory
+            - name: insights-qa-private-key
+              secret:
+                secretName: insights-qa-private-key
+                defaultMode: 384 # Means 0600
+                optional: true
+          containers:
+            - name: 'iqe-runner-playbook-dispatcher-e2e-tests-job-${IMAGE_TAG}-${UID}'
+              image: '${IQE_IMAGE}:${IQE_IMAGE_TAG}'
+              imagePullPolicy: Always
+              args:
+                - run
+              envFrom:
+                - secretRef:
+                    name: iqe-ibutsu-token
+                    optional: true
+                - configMapRef:
+                    name: '${CONFIGMAP_NAME}'
+              env:
+                - name: ENV_FOR_DYNACONF
+                  value: '${ENV_FOR_DYNACONF}'
+                - name: DYNACONF_MAIN__use_beta
+                  value: '${USE_BETA}'
+                - name: IBUTSU_SOURCE
+                  value: 'playbook-dispatcher-${IMAGE_TAG}-${UID}'
+                - name: IQE_BROWSERLOG
+                  value: '${IQE_BROWSERLOG}'
+                - name: IQE_NETLOG
+                  value: '${IQE_NETLOG}'
+                - name: IQE_PLUGINS
+                  value: 'playbook-dispatcher'
+                - name: IQE_MARKER_EXPRESSION
+                  value: '${IQE_MARKER_EXPRESSION}'
+                - name: IQE_FILTER_EXPRESSION
+                  value: '${IQE_FILTER_EXPRESSION}'
+                - name: IQE_LOG_LEVEL
+                  value: '${IQE_LOG_LEVEL}'
+                - name: IQE_REQUIREMENTS
+                  value: '${IQE_REQUIREMENTS}'
+                - name: IQE_REQUIREMENTS_PRIORITY
+                  value: '${IQE_REQUIREMENTS_PRIORITY}'
+                - name: IQE_TEST_IMPORTANCE
+                  value: '${IQE_TEST_IMPORTANCE}'
+                - name: IQE_PROMETHEUS_ENABLED
+                  value: '${IQE_PROMETHEUS_ENABLED}'
+                - name: DYNACONF_IQE_VAULT_LOADER_ENABLED
+                  value: 'true'
+                - name: DYNACONF_IQE_VAULT_VERIFY
+                  value: 'true'
+                - name: DYNACONF_DEFAULT_USER
+                  value: '${DYNACONF_DEFAULT_USER}'
+                - name: DYNACONF_IQE_VAULT_URL
+                  valueFrom:
+                    secretKeyRef:
+                      key: url
+                      name: iqe-vault
+                      optional: true
+                - name: DYNACONF_IQE_VAULT_MOUNT_POINT
+                  valueFrom:
+                    secretKeyRef:
+                      key: mountPoint
+                      name: iqe-vault
+                      optional: true
+                - name: DYNACONF_IQE_VAULT_ROLE_ID
+                  valueFrom:
+                    secretKeyRef:
+                      key: roleId
+                      name: iqe-vault
+                      optional: true
+                - name: DYNACONF_IQE_VAULT_SECRET_ID
+                  valueFrom:
+                    secretKeyRef:
+                      key: secretId
+                      name: iqe-vault
+                      optional: true
+                - name: PYTEST_ADDOPTS
+                  value: '${PYTEST_ADDOPTS}'
+              ports:
+                - containerPort: 9091
+                  name: metrics
+                  protocol: TCP
+              resources:
+                limits:
+                  cpu: '${IQE_LIMITS_CPU}'
+                  memory: '${IQE_LIMITS_MEMORY}'
+                requests:
+                  cpu: '${IQE_REQUESTS_CPU}'
+                  memory: '${IQE_REQUESTS_MEMORY}'
+              volumeMounts:
+                - name: insights-qa-private-key
+                  mountPath: /iqe_venv/.ssh
+                  readOnly: true
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+          initContainers:
+            - name: 'iqe-sel-${IMAGE_TAG}-${UID}'
+              image: '${IQE_SEL_IMAGE}'
+              env:
+                - name: _JAVA_OPTIONS
+                  value: '${SELENIUM_JAVA_OPTS}'
+                - name: SE_NODE_MAX_SESSIONS
+                  value: '${SE_NODE_MAX_SESSIONS}'
+                - name: SE_NODE_OVERRIDE_MAX_SESSIONS
+                  value: '${SE_NODE_OVERRIDE_MAX_SESSIONS}'
+              resources:
+                limits:
+                  cpu: '${SEL_LIMITS_CPU}'
+                  memory: '${SEL_LIMITS_MEMORY}'
+                requests:
+                  cpu: '${SEL_REQUESTS_CPU}'
+                  memory: '${SEL_REQUESTS_MEMORY}'
+              volumeMounts:
+                - name: sel-shm
+                  mountPath: /dev/shm
+              restartPolicy: Always # im a sidecar 🤡
+parameters:
+  - name: IMAGE_TAG
+    value: ''
+    required: true
+  - name: UID
+    description: Unique job name suffix
+    generate: expression
+    from: '[a-z0-9]{6}'
+  - name: IQE_IMAGE
+    description: container image path for the iqe plugin
+    value: quay.io/cloudservices/iqe-tests
+  - name: IQE_PLUGINS
+    value: 'playbook-dispatcher'
+    required: true
+  - name: IQE_IMAGE_TAG
+    value: ''
+  - name: ENV_FOR_DYNACONF
+    value: ''
+  - name: USE_BETA
+    value: 'true'
+  - name: IQE_MARKER_EXPRESSION
+    value: ''
+  - name: IQE_FILTER_EXPRESSION
+    value: ''
+  - name: IQE_LOG_LEVEL
+    value: info
+  - name: IQE_REQUIREMENTS
+    value: ''
+  - name: IQE_REQUIREMENTS_PRIORITY
+    value: ''
+  - name: IQE_TEST_IMPORTANCE
+    value: ''
+  - name: IQE_SEL_IMAGE
+    value: 'quay.io/app-sre/selenium-standalone-chrome:136.0-20250828'
+  - name: IQE_BROWSERLOG
+    value: '1'
+  - name: IQE_NETLOG
+    value: '1'
+  - name: NAME_STUB
+    value: ''
+  - name: SELENIUM_JAVA_OPTS
+    value: ''
+  - name: SE_NODE_MAX_SESSIONS
+    value: '2'
+  - name: SE_NODE_OVERRIDE_MAX_SESSIONS
+    value: 'true'
+  - name: IQE_LIMITS_CPU
+    value: '1.5'
+  - name: IQE_LIMITS_MEMORY
+    value: 1.5Gi
+  - name: IQE_REQUESTS_CPU
+    value: 250m
+  - name: IQE_REQUESTS_MEMORY
+    value: 512Mi
+  - name: SEL_LIMITS_CPU
+    value: 500m
+  - name: SEL_LIMITS_MEMORY
+    value: 2Gi
+  - name: SEL_REQUESTS_CPU
+    value: 100m
+  - name: SEL_REQUESTS_MEMORY
+    value: 256Mi
+  - name: DYNACONF_DEFAULT_USER
+    value: 'insights_qa'
+  - name: IQE_RP_ARGS
+    value: 'true'
+  - name: RP_LAUNCH_DESCRIPTION
+    value: ''
+  - name: RP_LAUNCH
+    value: ''
+  - name: RP_PROJECT
+    value: ''
+  - name: IQE_ENV_VARS
+    value: '' # KEY1=VALUE1,KEY2=VALUE2,
+  - name: CONFIGMAP_NAME
+    value: 'ibutsu-config'
+  - name: IQE_PROMETHEUS_ENABLED
+    value: 'true'
+  - name: PIPELINE_TIMEOUT
+    description: Max pipeline runtime in seconds before termination (default 6h)
+    value: '21600'
+  - name: PYTEST_ADDOPTS
+    value: ''
+    description: Example value "--foobar1 --foobar2=value"


### PR DESCRIPTION
## What?
I removed the sre-testing-templates sub module from this repo. Now I am adding the needed template files (from sre-testing-templates) to the repo.

https://redhat.atlassian.net/browse/RHINENG-26361

## Why?
This will re enable our e2e appsre pipelines.

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Add in-repo OpenShift templates for running playbook-dispatcher IQE e2e tests as ad-hoc jobs and scheduled cronjobs to replace the removed sre-testing-templates submodule.

New Features:
- Introduce a job template for running playbook-dispatcher IQE e2e tests on demand in the PD cluster.
- Introduce a cronjob template for scheduling recurring playbook-dispatcher IQE e2e test runs with configurable timing and resource parameters.