### PR TITLE
Remove selinum env vars and init container

### DIFF
--- a/deploy/iqe-cronjob-template.yaml
+++ b/deploy/iqe-cronjob-template.yaml
@@ -129,23 +129,6 @@ objects:
                       readOnly: true
                   terminationMessagePath: /dev/termination-log
                   terminationMessagePolicy: File
-              initContainers:
-                - name: 'iqe-sel-${IMAGE_TAG}-${UID}'
-                  image: '${IQE_SEL_IMAGE}'
-                  env:
-                    - name: _JAVA_OPTIONS
-                      value: '${SELENIUM_JAVA_OPTS}'
-                    - name: SE_NODE_MAX_SESSIONS
-                      value: '${SE_NODE_MAX_SESSIONS}'
-                    - name: SE_NODE_OVERRIDE_MAX_SESSIONS
-                      value: '${SE_NODE_OVERRIDE_MAX_SESSIONS}'
-                  resources:
-                    limits:
-                      cpu: '${SEL_LIMITS_CPU}'
-                      memory: '${SEL_LIMITS_MEMORY}'
-                    requests:
-                      cpu: '${SEL_REQUESTS_CPU}'
-                      memory: '${SEL_REQUESTS_MEMORY}'
 parameters:
   - name: IMAGE_TAG
     value: ''
@@ -182,20 +165,12 @@ parameters:
     value: ''
   - name: IQE_TEST_IMPORTANCE
     value: ''
-  - name: IQE_SEL_IMAGE
-    value: 'quay.io/app-sre/selenium-standalone-chrome:136.0-20250828'
   - name: IQE_BROWSERLOG
     value: '1'
   - name: IQE_NETLOG
     value: '1'
   - name: NAME_STUB
     value: ''
-  - name: SELENIUM_JAVA_OPTS
-    value: ''
-  - name: SE_NODE_MAX_SESSIONS
-    value: '2'
-  - name: SE_NODE_OVERRIDE_MAX_SESSIONS
-    value: 'true'
   - name: IQE_LIMITS_CPU
     value: '1.5'
   - name: IQE_LIMITS_MEMORY

--- a/deploy/iqe-cronjob-template.yaml
+++ b/deploy/iqe-cronjob-template.yaml
@@ -179,14 +179,6 @@ parameters:
     value: 250m
   - name: IQE_REQUESTS_MEMORY
     value: 2Gi
-  - name: SEL_LIMITS_CPU
-    value: 500m
-  - name: SEL_LIMITS_MEMORY
-    value: 2Gi
-  - name: SEL_REQUESTS_CPU
-    value: 100m
-  - name: SEL_REQUESTS_MEMORY
-    value: 256Mi
   - name: DYNACONF_DEFAULT_USER
     value: 'playbook_dispatcher_1'
   - name: IQE_RP_ARGS


### PR DESCRIPTION
## What?
Removing selenium init container and associated env vars from the e2e test cron job template.

## Why?
Selenium is not used or needed and it may fix our e2e pipeline

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
No testing

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Remove unused Selenium init container and related configuration from the IQE e2e cronjob template.

Build:
- Clean up IQE cronjob template parameters by removing Selenium-related image and settings no longer in use.

Deployment:
- Drop Selenium init container from the IQE cronjob deployment template to simplify the e2e job configuration.