### PR TITLE
rhineng-24451: add send query for only app specified in call

### DIFF
--- a/internal/api/middleware/rbac.go
+++ b/internal/api/middleware/rbac.go
@@ -4,6 +4,7 @@
 package middleware
 
 import (
+	"maps"
 	"net/http"
 	"playbook-dispatcher/internal/api/instrumentation"
 	"playbook-dispatcher/internal/api/rbac"
@@ -13,6 +14,7 @@ import (
 	"playbook-dispatcher/internal/common/utils"
 	"reflect"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -174,6 +176,46 @@ func getRbacAllowedServices(permissions []rbac.Access) []string {
 	return rbac.GetPredicateValues(permissions, "service")
 }
 
+// extractServicesToCheck determines which services to check based on request query parameters
+// Returns a map of service names to their kessel permissions
+func extractServicesToCheck(ctx echo.Context, log *zap.SugaredLogger) map[string]string {
+	var serviceFilter string
+
+	// Try to get service from filter[service] (runs endpoint)
+	serviceFilter = ctx.QueryParam("filter[service]")
+
+	// If not found, try filter[run][service] (run_hosts endpoint)
+	if serviceFilter == "" {
+		serviceFilter = ctx.QueryParam("filter[run][service]")
+	}
+
+	// If a service filter is specified, validate and check only that service
+	if serviceFilter != "" {
+		// Normalize: trim spaces
+		serviceFilter = strings.TrimSpace(serviceFilter)
+
+		if permission, exists := kessel.V2ApplicationPermissions[serviceFilter]; exists {
+			log.Debugw("Service filter detected, checking single service",
+				"service", serviceFilter)
+			return map[string]string{serviceFilter: permission}
+		}
+
+		// Invalid service name - don't fall back to all services for security
+		// If user explicitly filters for non-existent service, deny access
+		log.Warnw("Invalid service filter, returning no services to check",
+			"service", serviceFilter)
+		return map[string]string{}
+	}
+
+	// No filter - check all services
+	// Return a copy to prevent callers from mutating the global V2ApplicationPermissions map
+	log.Debugw("No service filter, checking all services")
+	servicesCopy := make(map[string]string, len(kessel.V2ApplicationPermissions))
+	maps.Copy(servicesCopy, kessel.V2ApplicationPermissions)
+
+	return servicesCopy
+}
+
 // getKesselAllowedServices queries Kessel for allowed services
 func getKesselAllowedServices(ctx echo.Context, log *zap.SugaredLogger) []string {
 	// Extract identity from context
@@ -222,8 +264,12 @@ func getKesselAllowedServices(ctx echo.Context, log *zap.SugaredLogger) []string
 		return []string{} // Return empty list on error
 	}
 
-	// Check permissions via Kessel (uses V2ApplicationPermissions map)
-	allowedServices, err := kessel.CheckApplicationPermissions(ctx.Request().Context(), workspaceID, log)
+	// Extract service filter from request query parameters
+	// Supports both filter[service] (runs endpoint) and filter[run][service] (run_hosts endpoint)
+	servicesToCheck := extractServicesToCheck(ctx, log)
+
+	// Check permissions via Kessel
+	allowedServices, err := kessel.CheckApplicationPermissions(ctx.Request().Context(), workspaceID, log, servicesToCheck)
 	if err != nil {
 		log.Errorw("Kessel authorization error",
 			"error", err,

--- a/internal/api/middleware/rbac_kessel_test.go
+++ b/internal/api/middleware/rbac_kessel_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"playbook-dispatcher/internal/api/rbac"
+	"playbook-dispatcher/internal/common/kessel"
 	"playbook-dispatcher/internal/common/utils"
 	"testing"
 
@@ -88,4 +89,80 @@ func TestLogComparison_OneEmpty(t *testing.T) {
 
 	// Should handle mismatch when one is empty
 	logComparison(ctx, rbacServices, kesselServices, log)
+}
+
+func TestExtractServicesToCheck_ReturnsImmutableCopy(t *testing.T) {
+	e := echo.New()
+	log := zap.NewNop().Sugar()
+
+	// Request with no service filter - should return copy of all services
+	req := httptest.NewRequest(http.MethodGet, "/api/playbook-dispatcher/v1/runs", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	// Get the original count
+	originalCount := len(kessel.V2ApplicationPermissions)
+	assert.Equal(t, 3, originalCount) // Ensure we start with 3 services
+
+	// Get services from helper
+	result := extractServicesToCheck(ctx, log)
+
+	// Verify we got all services
+	assert.Equal(t, 3, len(result))
+
+	// Mutate the returned map
+	result["malicious_service"] = "malicious_permission"
+
+	// Verify the global map is unchanged
+	assert.Equal(t, originalCount, len(kessel.V2ApplicationPermissions))
+	_, exists := kessel.V2ApplicationPermissions["malicious_service"]
+	assert.False(t, exists, "Global V2ApplicationPermissions should not be mutated")
+}
+
+func TestExtractServicesToCheck_WithFilter(t *testing.T) {
+	e := echo.New()
+	log := zap.NewNop().Sugar()
+
+	// Request with service filter
+	req := httptest.NewRequest(http.MethodGet, "/api/playbook-dispatcher/v1/runs?filter[service]=remediations", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	result := extractServicesToCheck(ctx, log)
+
+	// Should return only the requested service
+	assert.Equal(t, 1, len(result))
+	assert.Contains(t, result, "remediations")
+	assert.Equal(t, kessel.PermissionRemediationsRunView, result["remediations"])
+}
+
+func TestExtractServicesToCheck_WithInvalidFilter(t *testing.T) {
+	e := echo.New()
+	log := zap.NewNop().Sugar()
+
+	// Request with invalid service filter
+	req := httptest.NewRequest(http.MethodGet, "/api/playbook-dispatcher/v1/runs?filter[service]=invalid_service", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	result := extractServicesToCheck(ctx, log)
+
+	// Should return empty map for invalid service (fail securely)
+	assert.Empty(t, result)
+}
+
+func TestExtractServicesToCheck_WithSpaces(t *testing.T) {
+	e := echo.New()
+	log := zap.NewNop().Sugar()
+
+	// Request with spaces in service filter
+	req := httptest.NewRequest(http.MethodGet, "/api/playbook-dispatcher/v1/runs?filter[service]=%20remediations%20", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	result := extractServicesToCheck(ctx, log)
+
+	// Should trim spaces and find the service
+	assert.Equal(t, 1, len(result))
+	assert.Contains(t, result, "remediations")
 }

--- a/internal/common/kessel/authorization.go
+++ b/internal/common/kessel/authorization.go
@@ -279,10 +279,10 @@ func GetWorkspaceID(ctx context.Context, orgID string, log *zap.SugaredLogger) (
 	return workspaceID, nil
 }
 
-// CheckApplicationPermissions checks V2 Kessel permissions for multiple applications
+// CheckApplicationPermissions checks V2 Kessel permissions for the provided applications
 // and returns a list of application names that the user has access to.
 //
-// This function loops through the V2 application-specific permissions:
+// This function loops through the provided servicesToCheck map and validates permissions:
 // - playbook-dispatcher:config_manager_run:read -> playbook_dispatcher_config_manager_run_view
 // - playbook-dispatcher:remediations_run:read -> playbook_dispatcher_remediations_run_view
 // - playbook-dispatcher:tasks_run:read -> playbook_dispatcher_tasks_run_view
@@ -291,6 +291,8 @@ func GetWorkspaceID(ctx context.Context, orgID string, log *zap.SugaredLogger) (
 //   - ctx: Request context containing identity information
 //   - workspaceID: The workspace resource ID to check permissions against
 //   - log: Logger for debugging and error reporting
+//   - servicesToCheck: Map of service names to their kessel permissions to check.
+//     Pass V2ApplicationPermissions to check all services, or a subset map for specific services.
 //
 // Returns:
 //   - allowedApps: List of application names the user has access to (e.g., ["remediations", "tasks"])
@@ -302,9 +304,9 @@ func GetWorkspaceID(ctx context.Context, orgID string, log *zap.SugaredLogger) (
 //   - Structural failures (client == nil, auth config issues, bad identity): Returns error immediately
 //   - This allows callers to distinguish system failures from legitimate authorization denials
 //
-// Example usage:
+// Example usage (check all services):
 //
-//	allowedApps, err := kessel.CheckApplicationPermissions(ctx, workspaceID, log)
+//	allowedApps, err := kessel.CheckApplicationPermissions(ctx, workspaceID, log, kessel.V2ApplicationPermissions)
 //	if err != nil {
 //	    log.Error("Kessel authorization system failure", err)
 //	    return http.StatusServiceUnavailable  // System issue, not auth denial
@@ -314,7 +316,23 @@ func GetWorkspaceID(ctx context.Context, orgID string, log *zap.SugaredLogger) (
 //	    return http.StatusForbidden  // Legitimate authorization denial
 //	}
 //	// allowedApps might be: []string{"remediations", "config_manager"}
-func CheckApplicationPermissions(ctx context.Context, workspaceID string, log *zap.SugaredLogger) ([]string, error) {
+//
+// Example usage (check specific service):
+//
+//	servicesToCheck := map[string]string{"remediations": kessel.PermissionRemediationsRunView}
+//	allowedApps, err := kessel.CheckApplicationPermissions(ctx, workspaceID, log, servicesToCheck)
+//	// Only checks permission for remediations service
+func CheckApplicationPermissions(ctx context.Context, workspaceID string, log *zap.SugaredLogger, servicesToCheck map[string]string) ([]string, error) {
+	// Guard against nil or empty maps
+	if servicesToCheck == nil {
+		log.Warnw("CheckApplicationPermissions called with nil servicesToCheck map")
+		return []string{}, nil
+	}
+	if len(servicesToCheck) == 0 {
+		log.Debugw("CheckApplicationPermissions called with empty servicesToCheck map, no services to check")
+		return []string{}, nil
+	}
+
 	// Validate client and extract identity once (shared across all permission checks)
 	// This detects structural failures early and avoids re-extracting identity for each app
 	xrhid, principalID, err := validateClientAndIdentity(ctx)
@@ -334,14 +352,14 @@ func CheckApplicationPermissions(ctx context.Context, workspaceID string, log *z
 		return nil, fmt.Errorf("failed to get auth options: %w", err)
 	}
 
-	allowedApps := make([]string, 0, len(V2ApplicationPermissions))
+	allowedApps := make([]string, 0, len(servicesToCheck))
 
 	// Loop through each application and check its permission
 	// NOTE: We call checkPermissionInternal directly (instead of CheckPermission) to reuse
 	// the resolved identity, principal ID, and Kessel references across all permission checks.
 	// This avoids redundant identity extraction and reference building for each application,
 	// which is important when checking multiple permissions for the same user.
-	for appName, permission := range V2ApplicationPermissions {
+	for appName, permission := range servicesToCheck {
 		allowed, err := checkPermissionInternal(ctx, workspaceID, permission, log, xrhid, principalID, object, subject, opts, false)
 		if err != nil {
 			// Any error from checkPermissionInternal indicates a structural failure
@@ -363,7 +381,7 @@ func CheckApplicationPermissions(ctx context.Context, workspaceID string, log *z
 
 	log.Infow("Application permission check complete",
 		"allowed_apps", allowedApps,
-		"total_checked", len(V2ApplicationPermissions))
+		"total_checked", len(servicesToCheck))
 
 	return allowedApps, nil
 }

--- a/internal/common/kessel/authorization_test.go
+++ b/internal/common/kessel/authorization_test.go
@@ -543,7 +543,7 @@ func TestCheckApplicationPermissions_Success(t *testing.T) {
 	ctx := identity.WithIdentity(context.Background(), xrhid)
 	log := zap.NewNop().Sugar()
 
-	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", log)
+	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", log, V2ApplicationPermissions)
 
 	assert.NoError(t, err)
 	assert.Len(t, allowedApps, 3) // All 3 applications
@@ -580,7 +580,7 @@ func TestCheckApplicationPermissions_PartialAccess(t *testing.T) {
 	ctx := identity.WithIdentity(context.Background(), xrhid)
 	log := zap.NewNop().Sugar()
 
-	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", log)
+	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", log, V2ApplicationPermissions)
 
 	assert.NoError(t, err)
 	assert.Len(t, allowedApps, 1)
@@ -607,7 +607,7 @@ func TestCheckApplicationPermissions_NoAccess(t *testing.T) {
 	ctx := identity.WithIdentity(context.Background(), xrhid)
 	log := zap.NewNop().Sugar()
 
-	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", log)
+	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", log, V2ApplicationPermissions)
 
 	assert.NoError(t, err)
 	assert.Empty(t, allowedApps)
@@ -630,7 +630,7 @@ func TestCheckApplicationPermissions_KesselError(t *testing.T) {
 	ctx := identity.WithIdentity(context.Background(), xrhid)
 	log := zap.NewNop().Sugar()
 
-	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", log)
+	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", log, V2ApplicationPermissions)
 
 	assert.Error(t, err)
 	assert.Nil(t, allowedApps)
@@ -650,11 +650,85 @@ func TestCheckApplicationPermissions_ClientNotInitialized(t *testing.T) {
 	ctx := identity.WithIdentity(context.Background(), xrhid)
 	log := zap.NewNop().Sugar()
 
-	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", log)
+	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", log, V2ApplicationPermissions)
 
 	assert.Error(t, err)
 	assert.Nil(t, allowedApps)
 	assert.Contains(t, err.Error(), "cannot perform authorization checks")
+}
+
+func TestCheckApplicationPermissions_SingleService(t *testing.T) {
+	callCount := 0
+	mockService := &mockKesselInventoryService{}
+
+	// Set up response generator that tracks calls
+	mockService.checkFunc = func(ctx context.Context, in *kesselv2.CheckRequest, opts ...grpc.CallOption) (*kesselv2.CheckResponse, error) {
+		callCount++
+		// Allow the requested service
+		if in.Relation == PermissionRemediationsRunView {
+			return &kesselv2.CheckResponse{Allowed: kesselv2.Allowed_ALLOWED_TRUE}, nil
+		}
+		return &kesselv2.CheckResponse{Allowed: kesselv2.Allowed_ALLOWED_FALSE}, nil
+	}
+
+	cleanup := setupMockClient(mockService)
+	defer cleanup()
+
+	xrhid := identity.XRHID{
+		Identity: identity.Identity{
+			Type:  "User",
+			User:  &identity.User{UserID: "user-123"},
+			OrgID: "org-456",
+		},
+	}
+	ctx := identity.WithIdentity(context.Background(), xrhid)
+	log := zap.NewNop().Sugar()
+
+	// Check only remediations service
+	servicesToCheck := map[string]string{"remediations": PermissionRemediationsRunView}
+	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", log, servicesToCheck)
+
+	assert.NoError(t, err)
+	assert.Len(t, allowedApps, 1)
+	assert.Contains(t, allowedApps, "remediations")
+	assert.Equal(t, 1, callCount) // Should only check 1 application (not all 3)
+}
+
+func TestCheckApplicationPermissions_NilMap(t *testing.T) {
+	// No need to set up mock client since we should return early
+	xrhid := identity.XRHID{
+		Identity: identity.Identity{
+			Type:  "User",
+			User:  &identity.User{UserID: "user-123"},
+			OrgID: "org-456",
+		},
+	}
+	ctx := identity.WithIdentity(context.Background(), xrhid)
+	log := zap.NewNop().Sugar()
+
+	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", log, nil)
+
+	assert.NoError(t, err)
+	assert.Empty(t, allowedApps)
+}
+
+func TestCheckApplicationPermissions_EmptyMap(t *testing.T) {
+	// No need to set up mock client since we should return early
+	xrhid := identity.XRHID{
+		Identity: identity.Identity{
+			Type:  "User",
+			User:  &identity.User{UserID: "user-123"},
+			OrgID: "org-456",
+		},
+	}
+	ctx := identity.WithIdentity(context.Background(), xrhid)
+	log := zap.NewNop().Sugar()
+
+	emptyMap := map[string]string{}
+	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", log, emptyMap)
+
+	assert.NoError(t, err)
+	assert.Empty(t, allowedApps)
 }
 
 func TestBuildKesselReferences_Success(t *testing.T) {


### PR DESCRIPTION
## What?
feat: add service-scoped Kessel authorization checks

# OVERVIEW
* Extend Kessel application permission checks to accept an explicit set of services, allowing callers to check either all or a subset of applications.
* Introduce request-aware service selection in RBAC middleware based on query parameters, including secure handling of invalid service filters.
* Ensure the global Kessel permissions map remains immutable by returning defensive copies and covering the new behavior with targeted unit tests.

Fixes: RHINENG-24451

## Summary by Sourcery

Scope Kessel authorization checks to an explicit set of services and wire this into RBAC middleware so that permissions are evaluated only for the requested applications.

New Features:
- Allow callers of CheckApplicationPermissions to specify a map of services to check instead of always using the full V2 application permissions set.
- Derive the services to authorize from HTTP query parameters in RBAC middleware, including support for per-endpoint service filters.

Enhancements:
- Fail securely by returning no authorized services when an invalid service filter is provided, and by short-circuiting when the service map is nil or empty.
- Protect the global V2ApplicationPermissions map from mutation by returning defensive copies for middleware consumers.

Tests:
- Extend Kessel authorization tests to cover service-scoped permission checks and nil/empty service maps.
- Add RBAC middleware tests to verify service extraction behavior, immutability of the global permissions map, handling of invalid filters, and normalization of service values.