### PR TITLE
Update the job template so it can be shared by e2e and post deploy te…

### DIFF
--- a/deploy/iqe-job-template.yaml
+++ b/deploy/iqe-job-template.yaml
@@ -1,12 +1,12 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: 'playbook-dispatcher-e2e-tests-job'
+  name: '${IQE_PLUGINS}-test-job'
 objects:
   - apiVersion: batch/v1
     kind: Job
     metadata:
-      name: 'playbook-dispatcher-e2e-tests-job'
+      name: '${NAME_STUB}-pipeline'
       annotations:
         ignore-check.kube-linter.io/no-liveness-probe: probes not required on Job pods
         ignore-check.kube-linter.io/no-readiness-probe: probes not required on Job pods
@@ -31,7 +31,7 @@ objects:
                 defaultMode: 384 # Means 0600
                 optional: true
           containers:
-            - name: 'iqe-runner-playbook-dispatcher-e2e-tests-job-${IMAGE_TAG}-${UID}'
+            - name: 'iqe-runner-${NAME_STUB}-job-${IMAGE_TAG}-${UID}'
               image: '${IQE_IMAGE}:${IQE_IMAGE_TAG}'
               imagePullPolicy: Always
               args:
@@ -39,6 +39,9 @@ objects:
               envFrom:
                 - secretRef:
                     name: iqe-ibutsu-token
+                    optional: true
+                - secretRef:
+                    name: 'ibutsu-aws-credentials'
                     optional: true
                 - configMapRef:
                     name: '${CONFIGMAP_NAME}'
@@ -48,7 +51,7 @@ objects:
                 - name: DYNACONF_MAIN__use_beta
                   value: '${USE_BETA}'
                 - name: IBUTSU_SOURCE
-                  value: 'playbook-dispatcher-${IMAGE_TAG}-${UID}'
+                  value: '${IQE_PLUGINS}-saas-timer-${IMAGE_TAG}-${UID}'
                 - name: IQE_BROWSERLOG
                   value: '${IQE_BROWSERLOG}'
                 - name: IQE_NETLOG
@@ -147,7 +150,7 @@ parameters:
     description: container image path for the iqe plugin
     value: quay.io/cloudservices/iqe-tests
   - name: IQE_PLUGINS
-    value: '${IQE_PLUGINS}'
+    value: 'playbook-dispatcher'
     required: true
   - name: IQE_IMAGE_TAG
     value: ''

--- a/deploy/iqe-job-template.yaml
+++ b/deploy/iqe-job-template.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: '${IQE_PLUGINS}-test-job'
+  name: 'playbook-dispatcher-test-job'
 objects:
   - apiVersion: batch/v1
     kind: Job

--- a/deploy/iqe-job-template.yaml
+++ b/deploy/iqe-job-template.yaml
@@ -22,9 +22,6 @@ objects:
             - name: quay-cloudservices-pull
           restartPolicy: Never
           volumes:
-            - name: sel-shm
-              emptyDir:
-                medium: Memory
             - name: insights-qa-private-key
               secret:
                 secretName: insights-qa-private-key
@@ -121,23 +118,6 @@ objects:
                   readOnly: true
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
-          initContainers:
-            - name: 'iqe-sel-${IMAGE_TAG}-${UID}'
-              image: '${IQE_SEL_IMAGE}'
-              env:
-                - name: _JAVA_OPTIONS
-                  value: '${SELENIUM_JAVA_OPTS}'
-                - name: SE_NODE_MAX_SESSIONS
-                  value: '${SE_NODE_MAX_SESSIONS}'
-                - name: SE_NODE_OVERRIDE_MAX_SESSIONS
-                  value: '${SE_NODE_OVERRIDE_MAX_SESSIONS}'
-              resources:
-                limits:
-                  cpu: '${SEL_LIMITS_CPU}'
-                  memory: '${SEL_LIMITS_MEMORY}'
-                requests:
-                  cpu: '${SEL_REQUESTS_CPU}'
-                  memory: '${SEL_REQUESTS_MEMORY}'
 parameters:
   - name: IMAGE_TAG
     value: ''
@@ -170,20 +150,12 @@ parameters:
     value: ''
   - name: IQE_TEST_IMPORTANCE
     value: ''
-  - name: IQE_SEL_IMAGE
-    value: 'quay.io/app-sre/selenium-standalone-chrome:136.0-20250828'
   - name: IQE_BROWSERLOG
     value: '1'
   - name: IQE_NETLOG
     value: '1'
   - name: NAME_STUB
     value: ''
-  - name: SELENIUM_JAVA_OPTS
-    value: ''
-  - name: SE_NODE_MAX_SESSIONS
-    value: '2'
-  - name: SE_NODE_OVERRIDE_MAX_SESSIONS
-    value: 'true'
   - name: IQE_LIMITS_CPU
     value: '1.5'
   - name: IQE_LIMITS_MEMORY
@@ -192,14 +164,6 @@ parameters:
     value: 250m
   - name: IQE_REQUESTS_MEMORY
     value: 512Mi
-  - name: SEL_LIMITS_CPU
-    value: 500m
-  - name: SEL_LIMITS_MEMORY
-    value: 2Gi
-  - name: SEL_REQUESTS_CPU
-    value: 100m
-  - name: SEL_REQUESTS_MEMORY
-    value: 256Mi
   - name: DYNACONF_DEFAULT_USER
     value: 'playbook_dispatcher_1'
   - name: IQE_RP_ARGS


### PR DESCRIPTION
…sts. Add new ibutsu-aws-credentials secretref

## What?
I am adding e2e tests that use the template along with the post deploy tests. I am updating the parameters and env settings so the output will make sense and the two pipelines can share the template. I also added some additional ibutsu settings that are in the sre-testing-templates repo (where I copied the template from).
And I also removed settings related to selenium as it is not used by pipeline tests.

## Why?
We are implementing e2e pipelines that are run when we deploy PD to stage.

## How?
Only the openshift template file was updated.

## Testing
No

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Generalize the OpenShift IQE job template so it can be reused by multiple pipelines and align its configuration with existing SRE testing templates.

New Features:
- Allow customizing IQE job and pod names via NAME_STUB and IQE_PLUGINS-based naming.
- Add support for injecting AWS credentials into the IQE job via a new ibutsu-aws-credentials secret reference.

Enhancements:
- Standardize IBUTSU_SOURCE and container naming conventions to match shared SRE testing templates.
- Set a concrete default for IQE_PLUGINS to playbook-dispatcher for easier reuse of the template.