### PR TITLE
update kessel env feature flag

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -553,4 +553,4 @@ parameters:
 
 - name: KESSEL_AUTH_MODE
   description: Mode for feature flag testing (rbac-only, both-rbac-enforces, both-kessel-enforces, kessel-only)
-  value: 'rbac-only'
+  value: 'both-kessel-enforces'


### PR DESCRIPTION
## What?
Update the kessel mode environment var for Unleash fallback.

## Summary by Sourcery

Enhancements:
- Change the KESSEL_AUTH_MODE default from 'rbac-only' to 'both-kessel-enforces' in the deployment configuration.