### PR TITLE
switch kessel_auth_mode env var to kessel-only

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -550,7 +550,7 @@ parameters:
 - name: KESSEL_URL
   value: 'kessel-inventory-api:9000'
 - name: KESSEL_AUTH_ENABLED
-  value: 'false'
+  value: 'true'
 - name: KESSEL_AUTH_OIDC_ISSUER
 - name: KESSEL_INSECURE
   value: 'true'
@@ -559,4 +559,4 @@ parameters:
 
 - name: KESSEL_AUTH_MODE
   description: Mode for feature flag testing (rbac-only, both-rbac-enforces, both-kessel-enforces, kessel-only)
-  value: 'rbac-only'
+  value: 'kessel-only'


### PR DESCRIPTION
## What?
feat: update default feature flag auth mode to kessel-only

# OVERVIEW
* Changes the default KESSEL_AUTH_MODE parameter from rbac-only to kessel-only in the deployment configuration to alter the default feature flag authorization behavior.

Fixes: RHINENG-26924

## Summary by Sourcery

Update default Kessel feature flag authorization configuration.

Enhancements:
- Enable Kessel authorization by default in the deployment configuration.
- Change the default KESSEL_AUTH_MODE parameter from rbac-only to kessel-only for feature flag evaluation.