### PR TITLE
RHINENG-24451: limit kessel requests to specified service

### DIFF
--- a/internal/api/middleware/rbac.go
+++ b/internal/api/middleware/rbac.go
@@ -282,22 +282,38 @@ func getKesselAllowedServices(ctx echo.Context, log *zap.SugaredLogger) ([]strin
 		return nil, err // Return error for proper handling
 	}
 
+	// Extract service filter from request if single-service optimization is enabled
+	var serviceFilter string
+	if features.IsSingleServiceOptimizationEnabled(ctx.Request().Context()) {
+		if runFilters := GetDeepObject(ctx, "filter", "run"); len(runFilters) > 0 {
+			if service, ok := runFilters["service"]; ok {
+				// GetDeepObject returns []string, so extract the first value
+				if len(service) > 0 {
+					serviceFilter = service[0]
+					log.Debugw("Single-service optimization enabled, using service filter",
+						"service", serviceFilter)
+				}
+			}
+		}
+	}
+
 	// Check permissions via Kessel (uses V2ApplicationPermissions map)
 	var allowedServices []string
 
 	if features.IsApplicationCacheEnabled(ctx.Request().Context()) {
 		kesselCache := kessel.GetKesselClientWithCache()
 		if kesselCache != nil {
-			log.Debugw("Checking application permissions with cache", "workspace_id", workspaceID)
-			allowedServices, err = kesselCache.CheckApplicationPermissionsWithCache(ctx.Request().Context(), workspaceID, log)
+			log.Debugw("Checking application permissions with cache", "workspace_id", workspaceID, "service_filter", serviceFilter)
+			allowedServices, err = kesselCache.CheckApplicationPermissionsWithCache(ctx.Request().Context(), workspaceID, serviceFilter, log)
 		} else {
 			// Cache client not initialized, fall back to non-cached
-			log.Debugw("Cache client not initialized, using non-cached permission check", "workspace_id", workspaceID)
-			allowedServices, err = kessel.CheckApplicationPermissions(ctx.Request().Context(), workspaceID, log)
+			log.Debugw("Cache client not initialized, using non-cached permission check", "workspace_id", workspaceID, "service_filter", serviceFilter)
+			allowedServices, err = kessel.CheckApplicationPermissions(ctx.Request().Context(), workspaceID, serviceFilter, log)
 		}
 	} else {
-		allowedServices, err = kessel.CheckApplicationPermissions(ctx.Request().Context(), workspaceID, log)
+		allowedServices, err = kessel.CheckApplicationPermissions(ctx.Request().Context(), workspaceID, serviceFilter, log)
 	}
+
 
 	if err != nil {
 		log.Errorw("Kessel authorization error",

--- a/internal/common/kessel/authorization.go
+++ b/internal/common/kessel/authorization.go
@@ -418,10 +418,10 @@ func GetWorkspaceID(ctx context.Context, orgID string, log *zap.SugaredLogger) (
 	return workspaceID, nil
 }
 
-// CheckApplicationPermissions checks V2 Kessel permissions for multiple applications
+// CheckApplicationPermissions checks V2 Kessel permissions for applications
 // and returns a list of application names that the user has access to.
 //
-// This function loops through the V2 application-specific permissions:
+// This function can check permissions for one or all V2 application-specific permissions:
 // - playbook-dispatcher:config_manager_run:read -> playbook_dispatcher_config_manager_run_view
 // - playbook-dispatcher:remediations_run:read -> playbook_dispatcher_remediations_run_view
 // - playbook-dispatcher:tasks_run:read -> playbook_dispatcher_tasks_run_view
@@ -429,6 +429,9 @@ func GetWorkspaceID(ctx context.Context, orgID string, log *zap.SugaredLogger) (
 // Parameters:
 //   - ctx: Request context containing identity information
 //   - workspaceID: The workspace resource ID to check permissions against
+//   - serviceFilter: Optional service name to check (e.g., "config_manager", "remediations", "tasks").
+//     If provided and exists in V2ApplicationPermissions, only checks that service.
+//     If empty or not found, checks all services.
 //   - log: Logger for debugging and error reporting
 //
 // Returns:
@@ -443,7 +446,11 @@ func GetWorkspaceID(ctx context.Context, orgID string, log *zap.SugaredLogger) (
 //
 // Example usage:
 //
-//	allowedApps, err := kessel.CheckApplicationPermissions(ctx, workspaceID, log)
+//	// Check all services
+//	allowedApps, err := kessel.CheckApplicationPermissions(ctx, workspaceID, "", log)
+//
+//	// Check only the specified service (from request filter)
+//	allowedApps, err := kessel.CheckApplicationPermissions(ctx, workspaceID, "remediations", log)
 //	if err != nil {
 //	    log.Error("Kessel authorization system failure", err)
 //	    return http.StatusServiceUnavailable  // System issue, not auth denial
@@ -452,8 +459,7 @@ func GetWorkspaceID(ctx context.Context, orgID string, log *zap.SugaredLogger) (
 //	    log.Info("User has no application permissions")
 //	    return http.StatusForbidden  // Legitimate authorization denial
 //	}
-//	// allowedApps might be: []string{"remediations", "config_manager"}
-func CheckApplicationPermissions(ctx context.Context, workspaceID string, log *zap.SugaredLogger) ([]string, error) {
+func CheckApplicationPermissions(ctx context.Context, workspaceID string, serviceFilter string, log *zap.SugaredLogger) ([]string, error) {
 	// Validate client and extract identity once (shared across all permission checks)
 	// This detects structural failures early and avoids re-extracting identity for each app
 	xrhid, principalID, err := validateClientAndIdentity(ctx)
@@ -473,6 +479,29 @@ func CheckApplicationPermissions(ctx context.Context, workspaceID string, log *z
 		return nil, fmt.Errorf("failed to get auth options: %w", err)
 	}
 
+	// Determine which services to check based on the serviceFilter (single-service optimization)
+	var servicesToCheck map[string]string
+	if features.IsSingleServiceOptimizationEnabled(ctx) && serviceFilter != "" {
+		if permission, ok := V2ApplicationPermissions[serviceFilter]; ok {
+			log.Debugw("Checking single service based on filter",
+				"service", serviceFilter,
+				"permission", permission)
+			servicesToCheck = map[string]string{serviceFilter: permission}
+		} else {
+			log.Warnw("Invalid service filter provided, checking all known services",
+				"service_filter", serviceFilter)
+			servicesToCheck = V2ApplicationPermissions
+		}
+	} else {
+		log.Debugw("No service filter provided or optimization disabled, checking all services",
+			"total_services", len(V2ApplicationPermissions),
+			"service_filter", serviceFilter)
+		servicesToCheck = V2ApplicationPermissions
+	}
+
+	log.Debugw("Services to check for authorization",
+		"services", servicesToCheck)
+
 	var allowedApps []string
 
 	// Check feature flag to decide between bulk or individual checks
@@ -481,7 +510,7 @@ func CheckApplicationPermissions(ctx context.Context, workspaceID string, log *z
 		allowedApps, err = checkPermissionsBulk(
 			ctx,
 			workspaceID,
-			V2ApplicationPermissions,
+			servicesToCheck,
 			log,
 			xrhid,
 			principalID,
@@ -493,15 +522,15 @@ func CheckApplicationPermissions(ctx context.Context, workspaceID string, log *z
 			return nil, fmt.Errorf("bulk permission check failed: %w", err)
 		}
 	} else {
-		// Use individual checks (loop - original behavior)
-		allowedApps = make([]string, 0, len(V2ApplicationPermissions))
+		// Use individual checks (loop through servicesToCheck)
+		allowedApps = make([]string, 0, len(servicesToCheck))
 
 		// Loop through each application and check its permission
 		// NOTE: We call checkPermissionInternal directly (instead of CheckPermission) to reuse
 		// the resolved identity, principal ID, and Kessel references across all permission checks.
 		// This avoids redundant identity extraction and reference building for each application,
 		// which is important when checking multiple permissions for the same user.
-		for appName, permission := range V2ApplicationPermissions {
+		for appName, permission := range servicesToCheck {
 			allowed, err := checkPermissionInternal(ctx, workspaceID, permission, log, xrhid, principalID, object, subject, opts, false)
 			if err != nil {
 				// Any error from checkPermissionInternal indicates a structural failure
@@ -524,7 +553,7 @@ func CheckApplicationPermissions(ctx context.Context, workspaceID string, log *z
 
 	log.Infow("Application permission check complete",
 		"allowed_apps", allowedApps,
-		"total_checked", len(V2ApplicationPermissions))
+		"total_checked", len(servicesToCheck))
 
 	return allowedApps, nil
 }

--- a/internal/common/kessel/authorization_test.go
+++ b/internal/common/kessel/authorization_test.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
+	"playbook-dispatcher/internal/common/unleash/features"
 )
 
 // mockKesselInventoryService is a mock implementation of the Kessel inventory service
@@ -557,7 +558,7 @@ func TestCheckApplicationPermissions_Success(t *testing.T) {
 	ctx := identity.WithIdentity(context.Background(), xrhid)
 	log := zap.NewNop().Sugar()
 
-	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", log)
+	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", "", log)
 
 	assert.NoError(t, err)
 	assert.Len(t, allowedApps, 3) // All 3 applications
@@ -594,7 +595,7 @@ func TestCheckApplicationPermissions_PartialAccess(t *testing.T) {
 	ctx := identity.WithIdentity(context.Background(), xrhid)
 	log := zap.NewNop().Sugar()
 
-	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", log)
+	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", "", log)
 
 	assert.NoError(t, err)
 	assert.Len(t, allowedApps, 1)
@@ -621,7 +622,7 @@ func TestCheckApplicationPermissions_NoAccess(t *testing.T) {
 	ctx := identity.WithIdentity(context.Background(), xrhid)
 	log := zap.NewNop().Sugar()
 
-	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", log)
+	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", "", log)
 
 	assert.NoError(t, err)
 	assert.Empty(t, allowedApps)
@@ -644,7 +645,7 @@ func TestCheckApplicationPermissions_KesselError(t *testing.T) {
 	ctx := identity.WithIdentity(context.Background(), xrhid)
 	log := zap.NewNop().Sugar()
 
-	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", log)
+	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", "", log)
 
 	assert.Error(t, err)
 	assert.Nil(t, allowedApps)
@@ -665,11 +666,81 @@ func TestCheckApplicationPermissions_ClientNotInitialized(t *testing.T) {
 	ctx := identity.WithIdentity(context.Background(), xrhid)
 	log := zap.NewNop().Sugar()
 
-	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", log)
+	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", "", log)
 
 	assert.Error(t, err)
 	assert.Nil(t, allowedApps)
 	assert.Contains(t, err.Error(), "cannot perform authorization checks")
+}
+
+func TestCheckApplicationPermissions_WithServiceFilter(t *testing.T) {
+	callCount := 0
+	mockService := &mockKesselInventoryService{}
+
+	// Set up response generator that allows only remediations
+	mockService.checkFunc = func(ctx context.Context, in *kesselv2.CheckRequest, opts ...grpc.CallOption) (*kesselv2.CheckResponse, error) {
+		callCount++
+
+		// Only allow remediations
+		if in.Relation == PermissionRemediationsRunView {
+			return &kesselv2.CheckResponse{Allowed: kesselv2.Allowed_ALLOWED_TRUE}, nil
+		}
+		return &kesselv2.CheckResponse{Allowed: kesselv2.Allowed_ALLOWED_FALSE}, nil
+	}
+
+	cleanup := setupMockClient(mockService)
+	defer cleanup()
+
+	xrhid := identity.XRHID{
+		Identity: identity.Identity{
+			Type:  "User",
+			User:  &identity.User{UserID: "user-123"},
+			OrgID: "org-456",
+		},
+	}
+	ctx := context.Background()
+	// Enable single-service optimization for this test
+	ctx = features.WithSingleServiceOptimizationEnabled(ctx, true)
+	ctx = identity.WithIdentity(ctx, xrhid)
+	log := zap.NewNop().Sugar()
+
+	// Test with service filter - should only check one service
+	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", "remediations", log)
+
+	assert.NoError(t, err)
+	assert.Len(t, allowedApps, 1)
+	assert.Contains(t, allowedApps, "remediations")
+	assert.Equal(t, 1, callCount) // Should only check 1 application, not all 3
+}
+
+func TestCheckApplicationPermissions_WithInvalidServiceFilter(t *testing.T) {
+	callCount := 0
+	mockService := &mockKesselInventoryService{}
+
+	mockService.checkFunc = func(ctx context.Context, in *kesselv2.CheckRequest, opts ...grpc.CallOption) (*kesselv2.CheckResponse, error) {
+		callCount++
+		return &kesselv2.CheckResponse{Allowed: kesselv2.Allowed_ALLOWED_TRUE}, nil
+	}
+
+	cleanup := setupMockClient(mockService)
+	defer cleanup()
+
+	xrhid := identity.XRHID{
+		Identity: identity.Identity{
+			Type:  "User",
+			User:  &identity.User{UserID: "user-123"},
+			OrgID: "org-456",
+		},
+	}
+	ctx := identity.WithIdentity(context.Background(), xrhid)
+	log := zap.NewNop().Sugar()
+
+	// Test with invalid service filter - should check all services
+	allowedApps, err := CheckApplicationPermissions(ctx, "workspace-789", "invalid_service", log)
+
+	assert.NoError(t, err)
+	assert.Len(t, allowedApps, 3) // Should check all 3 applications
+	assert.Equal(t, 3, callCount)
 }
 
 func TestBuildKesselReferences_Success(t *testing.T) {

--- a/internal/common/kessel/cache.go
+++ b/internal/common/kessel/cache.go
@@ -26,7 +26,7 @@ type KesselClientWithCache struct {
 	applicationCache *cache.Cache
 	// permissionCheckFunc allows injecting a custom permission check function for testing
 	// Defaults to CheckApplicationPermissions if nil
-	permissionCheckFunc func(ctx context.Context, workspaceID string, log *zap.SugaredLogger) ([]string, error)
+	permissionCheckFunc func(ctx context.Context, workspaceID string, serviceFilter string, log *zap.SugaredLogger) ([]string, error)
 }
 
 // NewKesselClientWithCache creates a new Kessel client wrapper with caching
@@ -130,8 +130,8 @@ func (r *rbacClientImpl) GetDefaultWorkspaceIDWithCache(ctx context.Context, org
 }
 
 // CheckApplicationPermissionsWithCache performs application permission checks with caching
-// Cache key is a hash of: request_id + org_id + user_id + workspace_id
-func (k *KesselClientWithCache) CheckApplicationPermissionsWithCache(ctx context.Context, workspaceID string, log *zap.SugaredLogger) ([]string, error) {
+// Cache key is a hash of: request_id + org_id + user_id + workspace_id + service_filter
+func (k *KesselClientWithCache) CheckApplicationPermissionsWithCache(ctx context.Context, workspaceID string, serviceFilter string, log *zap.SugaredLogger) ([]string, error) {
 	reqID := request_id.GetReqID(ctx)
 	xrhid := identity.GetIdentity(ctx)
 	orgID := xrhid.Identity.OrgID
@@ -153,7 +153,7 @@ func (k *KesselClientWithCache) CheckApplicationPermissionsWithCache(ctx context
 
 	// NOTE: reqID can be externally provided by the calling application and may be
 	// the same across multiple endpoint requests, enabling cross-request caching
-	cacheKey := hashCacheKey("applications", reqID, orgID, userID, workspaceID)
+	cacheKey := hashCacheKey("applications", reqID, orgID, userID, workspaceID, serviceFilter)
 
 	// Check cache
 	if cached, found := k.applicationCache.Get(cacheKey); found {
@@ -187,7 +187,7 @@ func (k *KesselClientWithCache) CheckApplicationPermissionsWithCache(ctx context
 	if checkFunc == nil {
 		checkFunc = CheckApplicationPermissions
 	}
-	allowedApps, err := checkFunc(ctx, workspaceID, log)
+	allowedApps, err := checkFunc(ctx, workspaceID, serviceFilter, log)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/common/kessel/cache_test.go
+++ b/internal/common/kessel/cache_test.go
@@ -220,7 +220,7 @@ func TestCheckApplicationPermissionsWithCache_FallbackOnMissingRequestID(t *test
 
 	log := zap.NewNop().Sugar()
 
-	_, err := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-abc", log)
+	_, err := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-abc", "", log)
 
 	// Should return error for missing request_id
 	assert.Error(t, err)
@@ -244,7 +244,7 @@ func TestCheckApplicationPermissionsWithCache_FallbackOnMissingWorkspaceID(t *te
 
 	log := zap.NewNop().Sugar()
 
-	_, err := kesselCache.CheckApplicationPermissionsWithCache(ctx, "", log)
+	_, err := kesselCache.CheckApplicationPermissionsWithCache(ctx, "", "", log)
 
 	// Should return error for missing workspace_id (checked before request_id)
 	assert.Error(t, err)
@@ -349,7 +349,7 @@ func TestCheckApplicationPermissionsWithCache_CacheHit_AllowedApps(t *testing.T)
 
 	// Create mock permission check function with call counter
 	callCount := 0
-	mockPermissionCheck := func(ctx context.Context, workspaceID string, log *zap.SugaredLogger) ([]string, error) {
+	mockPermissionCheck := func(ctx context.Context, workspaceID string, serviceFilter string, log *zap.SugaredLogger) ([]string, error) {
 		callCount++
 		return []string{"remediations", "tasks"}, nil
 	}
@@ -361,13 +361,13 @@ func TestCheckApplicationPermissionsWithCache_CacheHit_AllowedApps(t *testing.T)
 	log := zap.NewNop().Sugar()
 
 	// First call - should hit backend
-	allowedApps1, err1 := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-abc", log)
+	allowedApps1, err1 := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-abc", "", log)
 	assert.NoError(t, err1)
 	assert.Equal(t, []string{"remediations", "tasks"}, allowedApps1)
 	assert.Equal(t, 1, callCount, "First call should invoke backend")
 
 	// Second call with same params - should hit cache
-	allowedApps2, err2 := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-abc", log)
+	allowedApps2, err2 := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-abc", "", log)
 	assert.NoError(t, err2)
 	assert.Equal(t, []string{"remediations", "tasks"}, allowedApps2)
 	assert.Equal(t, 1, callCount, "Second call should NOT invoke backend (cache hit)")
@@ -390,7 +390,7 @@ func TestCheckApplicationPermissionsWithCache_CacheHit_NoApps(t *testing.T) {
 
 	// Create mock that returns empty list (denied)
 	callCount := 0
-	mockPermissionCheck := func(ctx context.Context, workspaceID string, log *zap.SugaredLogger) ([]string, error) {
+	mockPermissionCheck := func(ctx context.Context, workspaceID string, serviceFilter string, log *zap.SugaredLogger) ([]string, error) {
 		callCount++
 		return []string{}, nil
 	}
@@ -402,13 +402,13 @@ func TestCheckApplicationPermissionsWithCache_CacheHit_NoApps(t *testing.T) {
 	log := zap.NewNop().Sugar()
 
 	// First call - should hit backend
-	allowedApps1, err1 := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-xyz", log)
+	allowedApps1, err1 := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-xyz", "", log)
 	assert.NoError(t, err1)
 	assert.Equal(t, []string{}, allowedApps1)
 	assert.Equal(t, 1, callCount, "First call should invoke backend")
 
 	// Second call - should hit cache (even for denied result)
-	allowedApps2, err2 := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-xyz", log)
+	allowedApps2, err2 := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-xyz", "", log)
 	assert.NoError(t, err2)
 	assert.Equal(t, []string{}, allowedApps2)
 	assert.Equal(t, 1, callCount, "Second call should NOT invoke backend (denied results are cached)")
@@ -431,7 +431,7 @@ func TestCheckApplicationPermissionsWithCache_DifferentCacheKeys(t *testing.T) {
 
 	// Create mock with call counter
 	callCount := 0
-	mockPermissionCheck := func(ctx context.Context, workspaceID string, log *zap.SugaredLogger) ([]string, error) {
+	mockPermissionCheck := func(ctx context.Context, workspaceID string, serviceFilter string, log *zap.SugaredLogger) ([]string, error) {
 		callCount++
 		// Return different results based on workspace
 		if workspaceID == "workspace-1" {
@@ -447,19 +447,19 @@ func TestCheckApplicationPermissionsWithCache_DifferentCacheKeys(t *testing.T) {
 	log := zap.NewNop().Sugar()
 
 	// Call with workspace-1
-	apps1, err1 := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-1", log)
+	apps1, err1 := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-1", "", log)
 	assert.NoError(t, err1)
 	assert.Equal(t, []string{"remediations"}, apps1)
 	assert.Equal(t, 1, callCount)
 
 	// Call with workspace-2 (different cache key)
-	apps2, err2 := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-2", log)
+	apps2, err2 := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-2", "", log)
 	assert.NoError(t, err2)
 	assert.Equal(t, []string{"tasks"}, apps2)
 	assert.Equal(t, 2, callCount, "Different workspace should be cache miss")
 
 	// Call workspace-1 again (cache hit)
-	apps3, err3 := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-1", log)
+	apps3, err3 := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-1", "", log)
 	assert.NoError(t, err3)
 	assert.Equal(t, []string{"remediations"}, apps3)
 	assert.Equal(t, 2, callCount, "Same workspace should be cache hit")
@@ -482,7 +482,7 @@ func TestCheckApplicationPermissionsWithCache_ErrorNotCached(t *testing.T) {
 
 	// Create mock that returns error
 	callCount := 0
-	mockPermissionCheck := func(ctx context.Context, workspaceID string, log *zap.SugaredLogger) ([]string, error) {
+	mockPermissionCheck := func(ctx context.Context, workspaceID string, serviceFilter string, log *zap.SugaredLogger) ([]string, error) {
 		callCount++
 		return nil, errors.New("backend error")
 	}
@@ -494,13 +494,13 @@ func TestCheckApplicationPermissionsWithCache_ErrorNotCached(t *testing.T) {
 	log := zap.NewNop().Sugar()
 
 	// First call - should fail
-	_, err1 := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-fail", log)
+	_, err1 := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-fail", "", log)
 	assert.Error(t, err1)
 	assert.Contains(t, err1.Error(), "backend error")
 	assert.Equal(t, 1, callCount)
 
 	// Second call - should try backend again (errors are not cached)
-	_, err2 := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-fail", log)
+	_, err2 := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-fail", "", log)
 	assert.Error(t, err2)
 	assert.Contains(t, err2.Error(), "backend error")
 	assert.Equal(t, 2, callCount, "Errors should NOT be cached")

--- a/internal/common/unleash/features/kessel.go
+++ b/internal/common/unleash/features/kessel.go
@@ -21,6 +21,9 @@ const (
 
 	// KesselBulkCheckFeatureFlag controls whether to use CheckBulk API or individual Check calls
 	KesselBulkCheckFeatureFlag = "playbook-dispatcher-kessel-bulkcheck"
+	// KesselSingleServiceOptimizationFeatureFlag controls whether to query only the specified service
+	// instead of all three services when a service filter is present in the request
+	KesselSingleServiceOptimizationFeatureFlag = "playbook-dispatcher-kessel-single-service"
 
 	// KesselWorkspaceCacheFeatureFlag controls whether to use caching for RBAC workspace lookups
 	KesselWorkspaceCacheFeatureFlag = "playbook-dispatcher-kessel-workspace-cache"
@@ -40,6 +43,13 @@ const (
 	ModeSourceEnvironmentUnleashFallback = "environment-unleash-fallback"
 	ModeSourceEnvironment           = "environment"
 	ModeSourceEnvironmentInvalid    = "environment-invalid"
+)
+
+// Context key for test overrides
+type contextKey string
+
+const (
+	testSingleServiceKey contextKey = "test-single-service-override"
 )
 
 // GetKesselAuthMode determines the current Kessel authorization mode WITHOUT context
@@ -321,4 +331,28 @@ func IsApplicationCacheEnabled(ctx context.Context) bool {
 	// Check if feature is enabled with context
 	// Returns false by default if feature flag not found or Unleash not initialized
 	return unleash.IsEnabledWithContext(KesselApplicationCacheFeatureFlag, unleashCtx)
+}
+
+// IsSingleServiceOptimizationEnabled checks if the single-service Kessel optimization is enabled
+// When enabled, if a service filter is present in the request, only that service's permission
+// will be checked instead of looping through all three services
+// Returns false by default (checks all services)
+// Returns true when enabled (only checks the specified service when filter is present)
+func IsSingleServiceOptimizationEnabled(ctx context.Context) bool {
+	// Check for test override first
+	if override, ok := ctx.Value(testSingleServiceKey).(bool); ok {
+		return override
+	}
+
+	// Build Unleash context from request context for per-org targeting
+	unleashCtx := buildUnleashContext(ctx, nil)
+
+	// Check if feature is enabled with context
+	// Returns false by default if feature flag not found or Unleash not initialized
+	return unleash.IsEnabledWithContext(KesselSingleServiceOptimizationFeatureFlag, unleashCtx)
+}
+
+// WithSingleServiceOptimizationEnabled returns a context with single-service optimization override for testing
+func WithSingleServiceOptimizationEnabled(ctx context.Context, enabled bool) context.Context {
+	return context.WithValue(ctx, testSingleServiceKey, enabled)
 }


### PR DESCRIPTION
## What?
feat(kessel): add single-service optimization for application permission checks

# OVERVIEW
* Extend Kessel application permission checks to optionally target a single service based on a request filter, falling back to all services when the filter is absent or invalid.
* Introduce an Unleash feature flag to control the single-service optimization behavior and wire it into RBAC middleware to derive the service filter from request parameters.
* Update authorization tests to cover the new service filter parameter and validate behavior for both valid and invalid service filters.

Fixes: RHINENG-24451

## Summary by Sourcery

Introduce optional single-service Kessel authorization optimization controlled by feature flag and consumed by RBAC middleware.

Enhancements:
- Add optional service filter parameter to Kessel application permission checks to allow targeting a single service or falling back to all services when unspecified or invalid.
- Introduce an Unleash feature flag to enable or disable the single-service optimization and wire it into RBAC middleware to derive the service filter from request run filters.

Tests:
- Update existing Kessel authorization tests for the new service filter parameter and add coverage for valid and invalid service filter scenarios.