### PR TITLE
add comment to dockerfile

### DIFF
--- a/event-streams/Dockerfile
+++ b/event-streams/Dockerfile
@@ -47,6 +47,8 @@ COPY --from=builder /deps/plugins $CONNECT_PLUGIN_PATH
 COPY --from=builder /deps/libs $CONNECT_LIB_PATH
 
 COPY event-streams/log4j.properties /opt/kafka/custom-config
+
+# removes unused cruise control files
 RUN rm -rf /opt/kafka-exporter
 
 USER 1001


### PR DESCRIPTION
Add comment for removal of unused cruise control files from event-streams image

# OVERVIEW
* Updates the event-streams Dockerfile to comment the deletion of unused /opt/kafka-exporter cruise control files during image build.