### PR TITLE
RHINENG-23603: add kessel bulk request

### DIFF
--- a/internal/common/kessel/authorization.go
+++ b/internal/common/kessel/authorization.go
@@ -12,6 +12,8 @@ import (
 	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+
+	"playbook-dispatcher/internal/common/unleash/features"
 )
 
 // validateClientAndIdentity performs common validation checks for authorization requests
@@ -121,7 +123,7 @@ func checkPermissionInternal(
 
 		response, err := globalManager.client.KesselInventoryService.CheckForUpdate(ctx, request, opts...)
 		if err != nil {
-			return false, fmt.Errorf("Kessel check for update failed: %w", err)
+			return false, fmt.Errorf("kessel check for update failed: %w", err)
 		}
 		allowed = response.GetAllowed() == kesselv2.Allowed_ALLOWED_TRUE
 
@@ -152,7 +154,7 @@ func checkPermissionInternal(
 
 		response, err := globalManager.client.KesselInventoryService.Check(ctx, request, opts...)
 		if err != nil {
-			return false, fmt.Errorf("Kessel check failed: %w", err)
+			return false, fmt.Errorf("kessel check failed: %w", err)
 		}
 		allowed = response.GetAllowed() == kesselv2.Allowed_ALLOWED_TRUE
 
@@ -164,6 +166,134 @@ func checkPermissionInternal(
 	}
 
 	return allowed, nil
+}
+
+// checkPermissionsBulk performs multiple Kessel authorization checks in a single bulk request
+// Returns a slice of application names that the user has permission for
+func checkPermissionsBulk(
+	ctx context.Context,
+	workspaceID string,
+	permissions map[string]string,
+	log *zap.SugaredLogger,
+	xrhid identity.XRHID,
+	principalID string,
+	object *kesselv2.ResourceReference,
+	subject *kesselv2.SubjectReference,
+	opts []grpc.CallOption,
+) ([]string, error) {
+	// Build bulk request items and create reverse lookup map (permission -> appName)
+	// INVARIANT: Each app must have a unique permission string in V2ApplicationPermissions.
+	// This is enforced at compile-time by the map structure and validated by tests.
+	items := make([]*kesselv2.CheckBulkRequestItem, 0, len(permissions))
+	permissionToApp := make(map[string]string, len(permissions))
+
+	for appName, permission := range permissions {
+		items = append(items, &kesselv2.CheckBulkRequestItem{
+			Object:   object,
+			Relation: permission,
+			Subject:  subject,
+		})
+		permissionToApp[permission] = appName
+	}
+
+	request := &kesselv2.CheckBulkRequest{
+		Items: items,
+	}
+
+	log.Debugw("Sending Kessel bulk permission check request",
+		"workspace_id", workspaceID,
+		"principal_id", principalID,
+		"org_id", xrhid.Identity.OrgID,
+		"num_checks", len(items))
+
+	response, err := globalManager.client.KesselInventoryService.CheckBulk(ctx, request, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("kessel bulk check failed: %w", err)
+	}
+
+	// Validate response structure
+	if response == nil {
+		return nil, fmt.Errorf("kessel bulk check returned nil response")
+	}
+
+	pairs := response.GetPairs()
+	if len(pairs) != len(items) {
+		// Log the mismatch but don't fail - treat missing pairs as denied
+		log.Warnw("Kessel bulk check response length mismatch",
+			"workspace_id", workspaceID,
+			"principal_id", principalID,
+			"org_id", xrhid.Identity.OrgID,
+			"requested_checks", len(items),
+			"received_pairs", len(pairs))
+	}
+
+	log.Debugw("Kessel bulk permission check complete",
+		"workspace_id", workspaceID,
+		"principal_id", principalID,
+		"num_responses", len(pairs))
+
+	// Process response pairs and collect allowed apps
+	// Use the echoed request in each pair to match back to app name
+	// Handle partial failures gracefully - bad pairs are treated as denied
+	allowedApps := []string{}
+	for _, pair := range pairs {
+		// Get the echoed request to determine which app this response is for
+		req := pair.GetRequest()
+		if req == nil {
+			log.Warnw("Bulk check response pair missing request echo, treating as denied",
+				"workspace_id", workspaceID,
+				"principal_id", principalID)
+			continue
+		}
+
+		relation := req.GetRelation()
+		appName, found := permissionToApp[relation]
+		if !found {
+			log.Warnw("Bulk check response contains unknown relation, treating as denied",
+				"workspace_id", workspaceID,
+				"principal_id", principalID,
+				"relation", relation)
+			continue
+		}
+
+		// Check if this pair has an error response - treat as denied for this app
+		if pairErr := pair.GetError(); pairErr != nil {
+			log.Warnw("Per-item error in bulk check response, treating as denied",
+				"workspace_id", workspaceID,
+				"principal_id", principalID,
+				"app", appName,
+				"permission", relation,
+				"error_code", pairErr.GetCode(),
+				"error_message", pairErr.GetMessage())
+			continue
+		}
+
+		// Get the response item
+		item := pair.GetItem()
+		if item == nil {
+			log.Warnw("Bulk check response pair missing item, treating as denied",
+				"workspace_id", workspaceID,
+				"principal_id", principalID,
+				"app", appName,
+				"permission", relation)
+			continue
+		}
+
+		// Check if allowed and log result (matches non-bulk logging)
+		allowed := item.GetAllowed() == kesselv2.Allowed_ALLOWED_TRUE
+		if allowed {
+			allowedApps = append(allowedApps, appName)
+			log.Debugw("User has access to application",
+				"app", appName,
+				"permission", relation)
+		} else {
+			log.Debugw("User does not have access to application",
+				"app", appName,
+				"permission", relation)
+		}
+	}
+
+	return allowedApps, nil
 }
 
 // CheckPermission performs a Kessel authorization check for a user's permission on a workspace
@@ -334,30 +464,52 @@ func CheckApplicationPermissions(ctx context.Context, workspaceID string, log *z
 		return nil, fmt.Errorf("failed to get auth options: %w", err)
 	}
 
-	allowedApps := make([]string, 0, len(V2ApplicationPermissions))
+	var allowedApps []string
 
-	// Loop through each application and check its permission
-	// NOTE: We call checkPermissionInternal directly (instead of CheckPermission) to reuse
-	// the resolved identity, principal ID, and Kessel references across all permission checks.
-	// This avoids redundant identity extraction and reference building for each application,
-	// which is important when checking multiple permissions for the same user.
-	for appName, permission := range V2ApplicationPermissions {
-		allowed, err := checkPermissionInternal(ctx, workspaceID, permission, log, xrhid, principalID, object, subject, opts, false)
+	// Check feature flag to decide between bulk or individual checks
+	if features.IsBulkCheckEnabled(ctx) {
+		// Use bulk check API (single network call for all permissions)
+		allowedApps, err = checkPermissionsBulk(
+			ctx,
+			workspaceID,
+			V2ApplicationPermissions,
+			log,
+			xrhid,
+			principalID,
+			object,
+			subject,
+			opts,
+		)
 		if err != nil {
-			// Any error from checkPermissionInternal indicates a structural failure
-			// (network error, auth issues) - return immediately
-			return nil, fmt.Errorf("structural failure checking permission for %s: %w", appName, err)
+			return nil, fmt.Errorf("bulk permission check failed: %w", err)
 		}
+	} else {
+		// Use individual checks (loop - original behavior)
+		allowedApps = make([]string, 0, len(V2ApplicationPermissions))
 
-		if allowed {
-			allowedApps = append(allowedApps, appName)
-			log.Debugw("User has access to application",
-				"app", appName,
-				"permission", permission)
-		} else {
-			log.Debugw("User does not have access to application",
-				"app", appName,
-				"permission", permission)
+		// Loop through each application and check its permission
+		// NOTE: We call checkPermissionInternal directly (instead of CheckPermission) to reuse
+		// the resolved identity, principal ID, and Kessel references across all permission checks.
+		// This avoids redundant identity extraction and reference building for each application,
+		// which is important when checking multiple permissions for the same user.
+		for appName, permission := range V2ApplicationPermissions {
+			allowed, err := checkPermissionInternal(ctx, workspaceID, permission, log, xrhid, principalID, object, subject, opts, false)
+			if err != nil {
+				// Any error from checkPermissionInternal indicates a structural failure
+				// (network error, auth issues) - return immediately
+				return nil, fmt.Errorf("structural failure checking permission for %s: %w", appName, err)
+			}
+
+			if allowed {
+				allowedApps = append(allowedApps, appName)
+				log.Debugw("User has access to application",
+					"app", appName,
+					"permission", permission)
+			} else {
+				log.Debugw("User does not have access to application",
+					"app", appName,
+					"permission", permission)
+			}
 		}
 	}
 

--- a/internal/common/kessel/authorization_test.go
+++ b/internal/common/kessel/authorization_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 )
 
@@ -19,9 +20,12 @@ type mockKesselInventoryService struct {
 	checkError             error
 	checkForUpdateResponse *kesselv2.CheckForUpdateResponse
 	checkForUpdateError    error
+	checkBulkResponse      *kesselv2.CheckBulkResponse
+	checkBulkError         error
 	lastCheckRequest       *kesselv2.CheckRequest
 	lastUpdateRequest      *kesselv2.CheckForUpdateRequest
 	checkFunc              func(ctx context.Context, in *kesselv2.CheckRequest, opts ...grpc.CallOption) (*kesselv2.CheckResponse, error)
+	checkBulkFunc          func(ctx context.Context, in *kesselv2.CheckBulkRequest, opts ...grpc.CallOption) (*kesselv2.CheckBulkResponse, error)
 }
 
 func (m *mockKesselInventoryService) Check(ctx context.Context, in *kesselv2.CheckRequest, opts ...grpc.CallOption) (*kesselv2.CheckResponse, error) {
@@ -54,7 +58,10 @@ func (m *mockKesselInventoryService) CheckSelf(ctx context.Context, in *kesselv2
 }
 
 func (m *mockKesselInventoryService) CheckBulk(ctx context.Context, in *kesselv2.CheckBulkRequest, opts ...grpc.CallOption) (*kesselv2.CheckBulkResponse, error) {
-	return nil, errors.New("not implemented")
+	if m.checkBulkFunc != nil {
+		return m.checkBulkFunc(ctx, in, opts...)
+	}
+	return m.checkBulkResponse, m.checkBulkError
 }
 
 func (m *mockKesselInventoryService) CheckForUpdateBulk(ctx context.Context, in *kesselv2.CheckForUpdateBulkRequest, opts ...grpc.CallOption) (*kesselv2.CheckForUpdateBulkResponse, error) {
@@ -196,7 +203,7 @@ func TestCheckPermission_KesselError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.False(t, allowed)
-	assert.Contains(t, err.Error(), "Kessel check failed")
+	assert.Contains(t, err.Error(), "kessel check failed")
 }
 
 func TestCheckPermission_EmptyWorkspaceID(t *testing.T) {
@@ -379,7 +386,7 @@ func TestCheckPermissionForUpdate_KesselError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.False(t, allowed)
-	assert.Contains(t, err.Error(), "Kessel check for update failed")
+	assert.Contains(t, err.Error(), "kessel check for update failed")
 }
 
 func TestCheckPermissionForUpdate_NoIdentityInContext(t *testing.T) {
@@ -698,6 +705,514 @@ func TestGetAuthCallOptions_NoTokenClient(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Empty(t, opts)
+}
+
+func TestCheckPermissionsBulk_Success(t *testing.T) {
+	mockService := &mockKesselInventoryService{
+		checkBulkResponse: &kesselv2.CheckBulkResponse{
+			Pairs: []*kesselv2.CheckBulkResponsePair{
+				{
+					Request: &kesselv2.CheckBulkRequestItem{
+						Relation: PermissionConfigManagerRunView,
+					},
+					Response: &kesselv2.CheckBulkResponsePair_Item{
+						Item: &kesselv2.CheckBulkResponseItem{
+							Allowed: kesselv2.Allowed_ALLOWED_TRUE,
+						},
+					},
+				},
+				{
+					Request: &kesselv2.CheckBulkRequestItem{
+						Relation: PermissionRemediationsRunView,
+					},
+					Response: &kesselv2.CheckBulkResponsePair_Item{
+						Item: &kesselv2.CheckBulkResponseItem{
+							Allowed: kesselv2.Allowed_ALLOWED_TRUE,
+						},
+					},
+				},
+				{
+					Request: &kesselv2.CheckBulkRequestItem{
+						Relation: PermissionTasksRunView,
+					},
+					Response: &kesselv2.CheckBulkResponsePair_Item{
+						Item: &kesselv2.CheckBulkResponseItem{
+							Allowed: kesselv2.Allowed_ALLOWED_TRUE,
+						},
+					},
+				},
+			},
+		},
+	}
+	cleanup := setupMockClient(mockService)
+	defer cleanup()
+
+	xrhid := identity.XRHID{
+		Identity: identity.Identity{
+			Type:  "User",
+			User:  &identity.User{UserID: "user-123"},
+			OrgID: "org-456",
+		},
+	}
+	log := zap.NewNop().Sugar()
+
+	object, subject, _ := buildKesselReferences("workspace-789", "redhat/user-123")
+	opts, _ := getAuthCallOptions()
+
+	allowedApps, err := checkPermissionsBulk(
+		context.Background(),
+		"workspace-789",
+		V2ApplicationPermissions,
+		log,
+		xrhid,
+		"redhat/user-123",
+		object,
+		subject,
+		opts,
+	)
+
+	assert.NoError(t, err)
+	assert.Len(t, allowedApps, 3)
+	assert.Contains(t, allowedApps, "config_manager")
+	assert.Contains(t, allowedApps, "remediations")
+	assert.Contains(t, allowedApps, "tasks")
+}
+
+func TestCheckPermissionsBulk_PartialAccess(t *testing.T) {
+	mockService := &mockKesselInventoryService{
+		checkBulkResponse: &kesselv2.CheckBulkResponse{
+			Pairs: []*kesselv2.CheckBulkResponsePair{
+				{
+					Request: &kesselv2.CheckBulkRequestItem{
+						Relation: PermissionConfigManagerRunView,
+					},
+					Response: &kesselv2.CheckBulkResponsePair_Item{
+						Item: &kesselv2.CheckBulkResponseItem{
+							Allowed: kesselv2.Allowed_ALLOWED_FALSE,
+						},
+					},
+				},
+				{
+					Request: &kesselv2.CheckBulkRequestItem{
+						Relation: PermissionRemediationsRunView,
+					},
+					Response: &kesselv2.CheckBulkResponsePair_Item{
+						Item: &kesselv2.CheckBulkResponseItem{
+							Allowed: kesselv2.Allowed_ALLOWED_TRUE,
+						},
+					},
+				},
+				{
+					Request: &kesselv2.CheckBulkRequestItem{
+						Relation: PermissionTasksRunView,
+					},
+					Response: &kesselv2.CheckBulkResponsePair_Item{
+						Item: &kesselv2.CheckBulkResponseItem{
+							Allowed: kesselv2.Allowed_ALLOWED_FALSE,
+						},
+					},
+				},
+			},
+		},
+	}
+	cleanup := setupMockClient(mockService)
+	defer cleanup()
+
+	xrhid := identity.XRHID{
+		Identity: identity.Identity{
+			Type:  "User",
+			User:  &identity.User{UserID: "user-123"},
+			OrgID: "org-456",
+		},
+	}
+	log := zap.NewNop().Sugar()
+
+	object, subject, _ := buildKesselReferences("workspace-789", "redhat/user-123")
+	opts, _ := getAuthCallOptions()
+
+	allowedApps, err := checkPermissionsBulk(
+		context.Background(),
+		"workspace-789",
+		V2ApplicationPermissions,
+		log,
+		xrhid,
+		"redhat/user-123",
+		object,
+		subject,
+		opts,
+	)
+
+	assert.NoError(t, err)
+	assert.Len(t, allowedApps, 1)
+	assert.Contains(t, allowedApps, "remediations")
+}
+
+func TestCheckPermissionsBulk_NoAccess(t *testing.T) {
+	mockService := &mockKesselInventoryService{
+		checkBulkResponse: &kesselv2.CheckBulkResponse{
+			Pairs: []*kesselv2.CheckBulkResponsePair{
+				{
+					Request: &kesselv2.CheckBulkRequestItem{
+						Relation: PermissionConfigManagerRunView,
+					},
+					Response: &kesselv2.CheckBulkResponsePair_Item{
+						Item: &kesselv2.CheckBulkResponseItem{
+							Allowed: kesselv2.Allowed_ALLOWED_FALSE,
+						},
+					},
+				},
+				{
+					Request: &kesselv2.CheckBulkRequestItem{
+						Relation: PermissionRemediationsRunView,
+					},
+					Response: &kesselv2.CheckBulkResponsePair_Item{
+						Item: &kesselv2.CheckBulkResponseItem{
+							Allowed: kesselv2.Allowed_ALLOWED_FALSE,
+						},
+					},
+				},
+				{
+					Request: &kesselv2.CheckBulkRequestItem{
+						Relation: PermissionTasksRunView,
+					},
+					Response: &kesselv2.CheckBulkResponsePair_Item{
+						Item: &kesselv2.CheckBulkResponseItem{
+							Allowed: kesselv2.Allowed_ALLOWED_FALSE,
+						},
+					},
+				},
+			},
+		},
+	}
+	cleanup := setupMockClient(mockService)
+	defer cleanup()
+
+	xrhid := identity.XRHID{
+		Identity: identity.Identity{
+			Type:  "User",
+			User:  &identity.User{UserID: "user-123"},
+			OrgID: "org-456",
+		},
+	}
+	log := zap.NewNop().Sugar()
+
+	object, subject, _ := buildKesselReferences("workspace-789", "redhat/user-123")
+	opts, _ := getAuthCallOptions()
+
+	allowedApps, err := checkPermissionsBulk(
+		context.Background(),
+		"workspace-789",
+		V2ApplicationPermissions,
+		log,
+		xrhid,
+		"redhat/user-123",
+		object,
+		subject,
+		opts,
+	)
+
+	assert.NoError(t, err)
+	assert.Empty(t, allowedApps)
+}
+
+func TestCheckPermissionsBulk_Error(t *testing.T) {
+	mockService := &mockKesselInventoryService{
+		checkBulkError: errors.New("kessel service unavailable"),
+	}
+	cleanup := setupMockClient(mockService)
+	defer cleanup()
+
+	xrhid := identity.XRHID{
+		Identity: identity.Identity{
+			Type:  "User",
+			User:  &identity.User{UserID: "user-123"},
+			OrgID: "org-456",
+		},
+	}
+	log := zap.NewNop().Sugar()
+
+	object, subject, _ := buildKesselReferences("workspace-789", "redhat/user-123")
+	opts, _ := getAuthCallOptions()
+
+	allowedApps, err := checkPermissionsBulk(
+		context.Background(),
+		"workspace-789",
+		V2ApplicationPermissions,
+		log,
+		xrhid,
+		"redhat/user-123",
+		object,
+		subject,
+		opts,
+	)
+
+	assert.Error(t, err)
+	assert.Nil(t, allowedApps)
+	assert.Contains(t, err.Error(), "kessel bulk check failed")
+}
+
+func TestCheckPermissionsBulk_ResponsePairError(t *testing.T) {
+	mockService := &mockKesselInventoryService{
+		checkBulkResponse: &kesselv2.CheckBulkResponse{
+			Pairs: []*kesselv2.CheckBulkResponsePair{
+				{
+					Request: &kesselv2.CheckBulkRequestItem{
+						Relation: PermissionConfigManagerRunView,
+					},
+					Response: &kesselv2.CheckBulkResponsePair_Error{
+						Error: &status.Status{
+							Code:    int32(5),
+							Message: "permission check failed",
+						},
+					},
+				},
+				{
+					Request: &kesselv2.CheckBulkRequestItem{
+						Relation: PermissionRemediationsRunView,
+					},
+					Response: &kesselv2.CheckBulkResponsePair_Item{
+						Item: &kesselv2.CheckBulkResponseItem{
+							Allowed: kesselv2.Allowed_ALLOWED_TRUE,
+						},
+					},
+				},
+				{
+					Request: &kesselv2.CheckBulkRequestItem{
+						Relation: PermissionTasksRunView,
+					},
+					Response: &kesselv2.CheckBulkResponsePair_Item{
+						Item: &kesselv2.CheckBulkResponseItem{
+							Allowed: kesselv2.Allowed_ALLOWED_TRUE,
+						},
+					},
+				},
+			},
+		},
+	}
+	cleanup := setupMockClient(mockService)
+	defer cleanup()
+
+	xrhid := identity.XRHID{
+		Identity: identity.Identity{
+			Type:  "User",
+			User:  &identity.User{UserID: "user-123"},
+			OrgID: "org-456",
+		},
+	}
+	log := zap.NewNop().Sugar()
+
+	object, subject, _ := buildKesselReferences("workspace-789", "redhat/user-123")
+	opts, _ := getAuthCallOptions()
+
+	allowedApps, err := checkPermissionsBulk(
+		context.Background(),
+		"workspace-789",
+		V2ApplicationPermissions,
+		log,
+		xrhid,
+		"redhat/user-123",
+		object,
+		subject,
+		opts,
+	)
+
+	// Per-item error is now treated as denied for that app, not a failure
+	assert.NoError(t, err)
+	assert.Len(t, allowedApps, 2) // remediations and tasks allowed, config_manager denied due to error
+	assert.Contains(t, allowedApps, "remediations")
+	assert.Contains(t, allowedApps, "tasks")
+	assert.NotContains(t, allowedApps, "config_manager")
+}
+
+func TestCheckPermissionsBulk_ResponseLengthMismatch(t *testing.T) {
+	mockService := &mockKesselInventoryService{
+		checkBulkResponse: &kesselv2.CheckBulkResponse{
+			Pairs: []*kesselv2.CheckBulkResponsePair{
+				{
+					Request: &kesselv2.CheckBulkRequestItem{
+						Relation: PermissionConfigManagerRunView,
+					},
+					Response: &kesselv2.CheckBulkResponsePair_Item{
+						Item: &kesselv2.CheckBulkResponseItem{
+							Allowed: kesselv2.Allowed_ALLOWED_TRUE,
+						},
+					},
+				},
+				// Only 1 pair returned but we send 3 items - should warn but not fail
+			},
+		},
+	}
+	cleanup := setupMockClient(mockService)
+	defer cleanup()
+
+	xrhid := identity.XRHID{
+		Identity: identity.Identity{
+			Type:  "User",
+			User:  &identity.User{UserID: "user-123"},
+			OrgID: "org-456",
+		},
+	}
+	log := zap.NewNop().Sugar()
+
+	object, subject, _ := buildKesselReferences("workspace-789", "redhat/user-123")
+	opts, _ := getAuthCallOptions()
+
+	allowedApps, err := checkPermissionsBulk(
+		context.Background(),
+		"workspace-789",
+		V2ApplicationPermissions,
+		log,
+		xrhid,
+		"redhat/user-123",
+		object,
+		subject,
+		opts,
+	)
+
+	// Length mismatch is now a warning, not an error - partial results are used
+	assert.NoError(t, err)
+	assert.Len(t, allowedApps, 1) // Only config_manager in response
+	assert.Contains(t, allowedApps, "config_manager")
+}
+
+func TestCheckPermissionsBulk_MissingRequestEcho(t *testing.T) {
+	mockService := &mockKesselInventoryService{
+		checkBulkResponse: &kesselv2.CheckBulkResponse{
+			Pairs: []*kesselv2.CheckBulkResponsePair{
+				{
+					// No Request field - should be skipped
+					Request: nil,
+					Response: &kesselv2.CheckBulkResponsePair_Item{
+						Item: &kesselv2.CheckBulkResponseItem{
+							Allowed: kesselv2.Allowed_ALLOWED_TRUE,
+						},
+					},
+				},
+				{
+					Request: &kesselv2.CheckBulkRequestItem{
+						Relation: PermissionRemediationsRunView,
+					},
+					Response: &kesselv2.CheckBulkResponsePair_Item{
+						Item: &kesselv2.CheckBulkResponseItem{
+							Allowed: kesselv2.Allowed_ALLOWED_TRUE,
+						},
+					},
+				},
+				{
+					Request: &kesselv2.CheckBulkRequestItem{
+						Relation: PermissionTasksRunView,
+					},
+					Response: &kesselv2.CheckBulkResponsePair_Item{
+						Item: &kesselv2.CheckBulkResponseItem{
+							Allowed: kesselv2.Allowed_ALLOWED_TRUE,
+						},
+					},
+				},
+			},
+		},
+	}
+	cleanup := setupMockClient(mockService)
+	defer cleanup()
+
+	xrhid := identity.XRHID{
+		Identity: identity.Identity{
+			Type:  "User",
+			User:  &identity.User{UserID: "user-123"},
+			OrgID: "org-456",
+		},
+	}
+	log := zap.NewNop().Sugar()
+
+	object, subject, _ := buildKesselReferences("workspace-789", "redhat/user-123")
+	opts, _ := getAuthCallOptions()
+
+	allowedApps, err := checkPermissionsBulk(
+		context.Background(),
+		"workspace-789",
+		V2ApplicationPermissions,
+		log,
+		xrhid,
+		"redhat/user-123",
+		object,
+		subject,
+		opts,
+	)
+
+	// Missing request echo is logged and skipped
+	assert.NoError(t, err)
+	assert.Len(t, allowedApps, 2)
+	assert.Contains(t, allowedApps, "remediations")
+	assert.Contains(t, allowedApps, "tasks")
+}
+
+func TestCheckPermissionsBulk_MissingItem(t *testing.T) {
+	mockService := &mockKesselInventoryService{
+		checkBulkResponse: &kesselv2.CheckBulkResponse{
+			Pairs: []*kesselv2.CheckBulkResponsePair{
+				{
+					Request: &kesselv2.CheckBulkRequestItem{
+						Relation: PermissionConfigManagerRunView,
+					},
+					Response: &kesselv2.CheckBulkResponsePair_Item{
+						Item: nil, // Missing item
+					},
+				},
+				{
+					Request: &kesselv2.CheckBulkRequestItem{
+						Relation: PermissionRemediationsRunView,
+					},
+					Response: &kesselv2.CheckBulkResponsePair_Item{
+						Item: &kesselv2.CheckBulkResponseItem{
+							Allowed: kesselv2.Allowed_ALLOWED_TRUE,
+						},
+					},
+				},
+				{
+					Request: &kesselv2.CheckBulkRequestItem{
+						Relation: PermissionTasksRunView,
+					},
+					Response: &kesselv2.CheckBulkResponsePair_Item{
+						Item: &kesselv2.CheckBulkResponseItem{
+							Allowed: kesselv2.Allowed_ALLOWED_TRUE,
+						},
+					},
+				},
+			},
+		},
+	}
+	cleanup := setupMockClient(mockService)
+	defer cleanup()
+
+	xrhid := identity.XRHID{
+		Identity: identity.Identity{
+			Type:  "User",
+			User:  &identity.User{UserID: "user-123"},
+			OrgID: "org-456",
+		},
+	}
+	log := zap.NewNop().Sugar()
+
+	object, subject, _ := buildKesselReferences("workspace-789", "redhat/user-123")
+	opts, _ := getAuthCallOptions()
+
+	allowedApps, err := checkPermissionsBulk(
+		context.Background(),
+		"workspace-789",
+		V2ApplicationPermissions,
+		log,
+		xrhid,
+		"redhat/user-123",
+		object,
+		subject,
+		opts,
+	)
+
+	// Missing item is logged and treated as denied
+	assert.NoError(t, err)
+	assert.Len(t, allowedApps, 2)
+	assert.Contains(t, allowedApps, "remediations")
+	assert.Contains(t, allowedApps, "tasks")
+	assert.NotContains(t, allowedApps, "config_manager")
 }
 
 // mockRbacClientWithWorkspace for testing workspace lookup

--- a/internal/common/unleash/features/kessel.go
+++ b/internal/common/unleash/features/kessel.go
@@ -19,6 +19,9 @@ const (
 	// KesselTokenTimeoutFeatureFlag is the name of the Unleash feature flag for token timeout/retry
 	KesselTokenTimeoutFeatureFlag = "playbook-dispatcher-kessel-tokentimeout"
 
+	// KesselBulkCheckFeatureFlag controls whether to use CheckBulk API or individual Check calls
+	KesselBulkCheckFeatureFlag = "playbook-dispatcher-kessel-bulkcheck"
+
 	// Variant names matching Unleash dashboard configuration
 	VariantRBACOnly           = "rbac-only"
 	VariantBothRBACEnforces   = "both-rbac-enforces"
@@ -276,4 +279,16 @@ func IsTokenTimeoutEnabled(ctx context.Context) bool {
 	// Check if feature is enabled with context
 	// Returns false by default if feature flag not found or Unleash not initialized
 	return unleash.IsEnabledWithContext(KesselTokenTimeoutFeatureFlag, unleashCtx)
+}
+
+// IsBulkCheckEnabled checks if the CheckBulk API feature is enabled
+// Returns false by default (uses loop of individual Check calls)
+// Returns true when enabled (uses single CheckBulk call)
+func IsBulkCheckEnabled(ctx context.Context) bool {
+	// Build Unleash context from request context for per-org targeting
+	unleashCtx := buildUnleashContext(ctx, nil)
+
+	// Check if feature is enabled with context
+	// Returns false by default if feature flag not found or Unleash not initialized
+	return unleash.IsEnabledWithContext(KesselBulkCheckFeatureFlag, unleashCtx)
 }


### PR DESCRIPTION
feat(kessel): add bulk permission check support controlled by feature flag

# OVERVIEW
* Introduces a bulk CheckBulk-based authorization path that evaluates multiple application permissions in a single Kessel call and returns the allowed applications.
* Adds comprehensive tests for the bulk permission checking flow, covering success, partial/no access, service errors, per-item errors, malformed responses, and missing data.
* Extends the mock Kessel inventory service to support configurable bulk check responses and errors for testing.
* Adds a new Unleash feature flag (playbook-dispatcher-kessel-bulkcheck) and helper to toggle between bulk and per-permission authorization checks at runtime.

Fixes: RHINENG-23603

## Summary by Sourcery

Add bulk Kessel authorization support for application permission checks, controlled by an Unleash feature flag.

New Features:
- Introduce a bulk CheckBulk-based authorization path that evaluates multiple application permissions in a single request and returns allowed applications.
- Add an Unleash feature flag to toggle between bulk and per-permission Kessel checks at runtime.

Enhancements:
- Extend the Kessel authorization logic to gracefully handle partial failures and malformed bulk responses without failing the entire permission evaluation.
- Expand the mock Kessel inventory service to support configurable bulk check responses used in authorization testing.

Tests:
- Add comprehensive tests covering successful, partial, and no-access bulk permission checks, service-level errors, per-item errors, response length mismatches, and missing request/item data.