### PR TITLE
RHINENG-25921; bump amq streams/kafka client version to 2.9.4-4

### DIFF
--- a/event-streams/Dockerfile
+++ b/event-streams/Dockerfile
@@ -26,7 +26,7 @@ RUN ./mvnw -Dschema.event.run=/src/run.event.yaml -Dschema.event.run.host=/src/r
 
 
 # https://access.redhat.com/documentation/en-us/red_hat_amq/2021.q3/html-single/deploying_and_upgrading_amq_streams_on_openshift/index#creating-new-image-from-base-str
-FROM registry.redhat.io/amq-streams/kafka-39-rhel9:2.9.3-31
+FROM registry.redhat.io/amq-streams/kafka-39-rhel9:2.9.4-4
 ARG BUILD_COMMIT=unknown
 
 ENV CONNECT_PLUGIN_PATH=/opt/kafka/plugins \


### PR DESCRIPTION
## What?
Updates AMQ Streams Image to bump Kafka client to to 2.9.4-4 

## Why?
To address RHINENG-25921

## How?
Just pulls a new image tag

## Testing
n/a

## Anything Else?
n/a

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
