### PR TITLE
RHINENG-28401: upgrade AMQ Streams to 4.2

### DIFF
--- a/event-streams/Dockerfile
+++ b/event-streams/Dockerfile
@@ -26,7 +26,7 @@ RUN ./mvnw -Dschema.event.run=/src/run.event.yaml -Dschema.event.run.host=/src/r
 
 
 # https://access.redhat.com/documentation/en-us/red_hat_amq/2021.q3/html-single/deploying_and_upgrading_amq_streams_on_openshift/index#creating-new-image-from-base-str
-FROM registry.redhat.io/amq-streams/kafka-39-rhel9:2.9.4-7
+FROM registry.redhat.io/amq-streams/kafka-42-rhel9:3.2.0-21
 ARG BUILD_COMMIT=unknown
 
 ENV CONNECT_PLUGIN_PATH=/opt/kafka/plugins \


### PR DESCRIPTION
## What?
chore(docker): update amq-streams kafka base image version

# OVERVIEW
* Update the event-streams Docker base image to a newer AMQ Streams Kafka RHEL9 version for alignment with the latest platform release.
