### PR TITLE
fix missing topics for PR check

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -56,6 +56,12 @@ objects:
     - replicas: 3
       partitions: 16
       topicName: platform.upload.validation
+    - replicas: 3
+      partitions: 16
+      topicName: platform.playbook-dispatcher.runs
+    - replicas: 3
+      partitions: 16
+      topicName: platform.playbook-dispatcher.run-hosts
 
     deployments:
     - name: api


### PR DESCRIPTION
## What?
feat: add Kafka topics for playbook dispatcher runs and hosts to fix PR check setup failures

## OVERVIEW
* Define two new Kafka topics in the ClowdApp configuration to support playbook dispatcher run and run-host messaging.