### PR TITLE
testing kessel enabled false

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -546,7 +546,7 @@ parameters:
   value: "hms_analytics/playbook-dispatcher/unknown"
 
 - name: KESSEL_ENABLED
-  value: 'true'
+  value: 'false'
 - name: KESSEL_URL
   value: 'kessel-inventory-api:9000'
 - name: KESSEL_AUTH_ENABLED


### PR DESCRIPTION
## What?
Testing kessel settings against different environments.

## Summary by Sourcery

Disable Kessel integration by setting the KESSEL_ENABLED deployment parameter to false in the clowdapp configuration.

Enhancements:
- Adjust Kessel-related deployment configuration to allow testing with the integration disabled.

Deployment:
- Update clowdapp deployment parameters to reflect Kessel being disabled by default.