### PR TITLE
[RHCLOUD-49129] Fetch default ws bypassing permission check

### DIFF
--- a/internal/common/kessel/rbac.go
+++ b/internal/common/kessel/rbac.go
@@ -186,7 +186,7 @@ func (r *rbacClientImpl) GetDefaultWorkspaceID(ctx context.Context, orgID string
 		}
 	}()
 
-	requestURL := fmt.Sprintf("%s/api/rbac/v2/workspaces/?type=default", r.rbacURL)
+	requestURL := fmt.Sprintf("%s/api/rbac/v2/workspaces/?type=default&with_ancestry=true", r.rbacURL)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", requestURL, nil)
 	if err != nil {

--- a/internal/common/kessel/rbac_test.go
+++ b/internal/common/kessel/rbac_test.go
@@ -32,6 +32,7 @@ func TestGetDefaultWorkspaceID_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Contains(t, r.URL.Path, "/api/rbac/v2/workspaces/")
 		assert.Equal(t, "default", r.URL.Query().Get("type"))
+		assert.Equal(t, "true", r.URL.Query().Get("with_ancestry"))
 		assert.Equal(t, "test-org", r.Header.Get("x-rh-rbac-org-id"))
 
 		w.Header().Set("Content-Type", "application/json")
@@ -298,6 +299,7 @@ func TestGetDefaultWorkspaceID_URLFormatting(t *testing.T) {
 	// Verify the URL format matches config-manager (no org_id query param)
 	assert.Contains(t, capturedURL, "/api/rbac/v2/workspaces/")
 	assert.Contains(t, capturedURL, "type=default")
+	assert.Contains(t, capturedURL, "with_ancestry=true")
 	assert.NotContains(t, capturedURL, "org_id")
 }
 


### PR DESCRIPTION
## What?
https://redhat.atlassian.net/browse/RHCLOUD-49129

## Why?
RBAC require explicit parameter to bypass the permission check when fetching default workspace

## How?
Add with_ancestry parameter

## Testing
Unit test

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Include the RBAC with_ancestry parameter when fetching the default workspace ID and validate it in tests.

Bug Fixes:
- Ensure default workspace fetch bypasses permission checks by requesting ancestry information from RBAC.

Tests:
- Extend RBAC client tests to assert the with_ancestry query parameter is present in default workspace requests.