### PR TITLE
RHINENG-30075: add singleflight to kessel caching

### DIFF
--- a/internal/common/kessel/cache.go
+++ b/internal/common/kessel/cache.go
@@ -18,12 +18,14 @@ import (
 	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
 	"github.com/redhatinsights/platform-go-middlewares/v2/request_id"
 	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
 )
 
 // KesselClientWithCache wraps the Kessel inventory client with application caching
 type KesselClientWithCache struct {
-	client           *v1beta2.InventoryClient
-	applicationCache *cache.Cache
+	client            *v1beta2.InventoryClient
+	applicationCache  *cache.Cache
+	applicationFlight singleflight.Group
 	// permissionCheckFunc allows injecting a custom permission check function for testing
 	// Defaults to CheckApplicationPermissions if nil
 	permissionCheckFunc func(ctx context.Context, workspaceID string, serviceFilter string, log *zap.SugaredLogger) ([]string, error)
@@ -111,19 +113,41 @@ func (r *rbacClientImpl) GetDefaultWorkspaceIDWithCache(ctx context.Context, org
 					"request_id", reqID,
 					"internal_request_id", utils.GetInternalRequestID(ctx),
 					"org_id", orgID,
-					"cache_key", cacheKey)
+					"cache_key", cacheKey,
+					"workspace_id", workspaceID)
 			}
 			return workspaceID, nil
 		}
 	}
 
-	// Cache miss - fetch from API
-	workspaceID, err := r.GetDefaultWorkspaceID(ctx, orgID)
+	// Cache miss - deduplicate concurrent API calls for the same key.
+	// NOTE: singleflight.Do uses the first caller's context; backend calls are
+	// still bounded by the RBAC/Kessel client timeout configured at client construction.
+	result, err, shared := r.workspaceFlight.Do(cacheKey, func() (interface{}, error) {
+		return r.GetDefaultWorkspaceID(ctx, orgID)
+	})
 	if err != nil {
 		return "", err
 	}
 
-	// Store in cache
+	workspaceID, ok := result.(string)
+	if !ok {
+		return "", fmt.Errorf("unexpected type from singleflight workspace lookup: %T", result)
+	}
+
+	// Log when request was deduped
+	if shared {
+		log := utils.GetLogFromContextIfAvailable(ctx)
+		if log != nil {
+			log.Debugw("Workspace lookup deduplicated via singleflight",
+				"request_id", reqID,
+				"internal_request_id", utils.GetInternalRequestID(ctx),
+				"org_id", orgID,
+				"cache_key", cacheKey,
+				"workspace_id", workspaceID)
+		}
+	}
+
 	r.workspaceCache.Set(cacheKey, workspaceID, cache.DefaultExpiration)
 
 	return workspaceID, nil
@@ -182,17 +206,37 @@ func (k *KesselClientWithCache) CheckApplicationPermissionsWithCache(ctx context
 		}
 	}
 
-	// Cache miss - check permissions via Kessel
-	checkFunc := k.permissionCheckFunc
-	if checkFunc == nil {
-		checkFunc = CheckApplicationPermissions
-	}
-	allowedApps, err := checkFunc(ctx, workspaceID, serviceFilter, log)
+	// Cache miss - deduplicate concurrent permission checks for the same key
+	result, err, shared := k.applicationFlight.Do(cacheKey, func() (interface{}, error) {
+		checkFunc := k.permissionCheckFunc
+		if checkFunc == nil {
+			checkFunc = CheckApplicationPermissions
+		}
+		return checkFunc(ctx, workspaceID, serviceFilter, log)
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	// Store in cache
+	allowedApps, ok := result.([]string)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type from singleflight application permissions lookup: %T", result)
+	}
+
+	// Log when request was deduped
+	if shared {
+		log := utils.GetLogFromContextIfAvailable(ctx)
+		if log != nil {
+			log.Debugw("Application permissions lookup deduplicated via singleflight",
+				"request_id", reqID,
+				"internal_request_id", utils.GetInternalRequestID(ctx),
+				"org_id", orgID,
+				"workspace_id", workspaceID,
+				"service_filter", serviceFilter,
+				"cache_key", cacheKey)
+		}
+	}
+
 	k.applicationCache.Set(cacheKey, allowedApps, cache.DefaultExpiration)
 
 	return allowedApps, nil

--- a/internal/common/kessel/cache_test.go
+++ b/internal/common/kessel/cache_test.go
@@ -312,7 +312,7 @@ func TestHashCacheKey_DifferentWorkspaces(t *testing.T) {
 	assert.NotEqual(t, hash1, hash2, "Different workspaces must produce different cache keys to prevent authorization leakage")
 }
 
-// Test helper to create a context with request_id set via middleware
+// contextWithRequestID creates a context with request_id set via middleware.
 func contextWithRequestID(t *testing.T) context.Context {
 	t.Helper()
 
@@ -504,4 +504,272 @@ func TestCheckApplicationPermissionsWithCache_ErrorNotCached(t *testing.T) {
 	assert.Error(t, err2)
 	assert.Contains(t, err2.Error(), "backend error")
 	assert.Equal(t, 2, callCount, "Errors should NOT be cached")
+}
+
+func TestCheckApplicationPermissionsWithCache_SingleflightDeduplication(t *testing.T) {
+	// Create context with request_id via middleware
+	ctx := contextWithRequestID(t)
+
+	// Add identity to context
+	ctx = identity.WithIdentity(ctx, identity.XRHID{
+		Identity: identity.Identity{
+			Type:  "User",
+			OrgID: "org-concurrent",
+			User: &identity.User{
+				UserID: "user-concurrent",
+			},
+		},
+	})
+
+	// Create mock with artificial delay to simulate slow backend
+	callCount := 0
+	mockPermissionCheck := func(ctx context.Context, workspaceID string, serviceFilter string, log *zap.SugaredLogger) ([]string, error) {
+		callCount++
+		time.Sleep(50 * time.Millisecond) // Delay to ensure concurrent calls overlap
+		return []string{"remediations", "tasks"}, nil
+	}
+
+	// Create cache client with mock
+	kesselCache := NewKesselClientWithCache(nil)
+	kesselCache.permissionCheckFunc = mockPermissionCheck
+
+	log := zap.NewNop().Sugar()
+
+	// Launch 5 concurrent requests
+	results := make(chan []string, 5)
+	errors := make(chan error, 5)
+
+	for i := 0; i < 5; i++ {
+		go func() {
+			apps, err := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-concurrent", "", log)
+			results <- apps
+			errors <- err
+		}()
+	}
+
+	// Collect all results
+	var allApps [][]string
+	var allErrors []error
+	for i := 0; i < 5; i++ {
+		allApps = append(allApps, <-results)
+		allErrors = append(allErrors, <-errors)
+	}
+
+	// Verify all succeeded
+	for i, err := range allErrors {
+		assert.NoError(t, err, "Request %d should succeed", i)
+	}
+
+	// Verify all got the same result
+	for i, apps := range allApps {
+		assert.Equal(t, []string{"remediations", "tasks"}, apps, "Request %d should get correct result", i)
+	}
+
+	// Most importantly: singleflight should deduplicate, so only 1 backend call
+	assert.Equal(t, 1, callCount, "Singleflight should deduplicate concurrent requests to 1 backend call")
+}
+
+// TestCheckApplicationPermissionsWithCache_TypeAssertionFailure verifies that corrupted cache entries
+// (wrong type) are detected, deleted, and recovered from gracefully.
+func TestCheckApplicationPermissionsWithCache_TypeAssertionFailure(t *testing.T) {
+	// Create context with request_id via middleware
+	ctx := contextWithRequestID(t)
+
+	// Add identity to context
+	ctx = identity.WithIdentity(ctx, identity.XRHID{
+		Identity: identity.Identity{
+			Type:  "User",
+			OrgID: "org-type",
+			User: &identity.User{
+				UserID: "user-type",
+			},
+		},
+	})
+
+	// Create mock permission check
+	mockPermissionCheck := func(ctx context.Context, workspaceID string, serviceFilter string, log *zap.SugaredLogger) ([]string, error) {
+		return []string{"remediations"}, nil
+	}
+
+	// Create cache client with mock
+	kesselCache := NewKesselClientWithCache(nil)
+	kesselCache.permissionCheckFunc = mockPermissionCheck
+
+	log := zap.NewNop().Sugar()
+
+	// First call succeeds normally
+	apps1, err1 := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-type", "", log)
+	assert.NoError(t, err1)
+	assert.Equal(t, []string{"remediations"}, apps1)
+
+	// Manually corrupt the cache with wrong type
+	reqID := request_id.GetReqID(ctx)
+	cacheKey := hashCacheKey("applications", reqID, "org-type", "user-type", "workspace-type", "")
+	kesselCache.applicationCache.Set(cacheKey, "wrong-type-string", cache.DefaultExpiration)
+
+	// Verify corrupted entry exists
+	corrupted, found := kesselCache.applicationCache.Get(cacheKey)
+	assert.True(t, found, "Corrupted cache entry should exist")
+	assert.Equal(t, "wrong-type-string", corrupted, "Should have corrupted value")
+
+	// Second call should detect type mismatch, delete corrupted entry, fetch fresh data, and cache it
+	apps2, err2 := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-type", "", log)
+	assert.NoError(t, err2, "Should recover from type mismatch by fetching fresh data")
+	assert.Equal(t, []string{"remediations"}, apps2, "Should return fresh data after cache corruption")
+
+	// Verify cache now contains correct data (not corrupted)
+	cached, found := kesselCache.applicationCache.Get(cacheKey)
+	assert.True(t, found, "Cache entry should exist with fresh data")
+	correctData, ok := cached.([]string)
+	assert.True(t, ok, "Cached data should be correct type now")
+	assert.Equal(t, []string{"remediations"}, correctData, "Cached data should be correct")
+}
+
+func TestGetDefaultWorkspaceIDWithCache_SingleflightDeduplication(t *testing.T) {
+	// Create a mock RBAC server that tracks call count
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		time.Sleep(50 * time.Millisecond) // Delay to ensure concurrent calls overlap
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(`{"data":[{"id":"workspace-123"}]}`)); err != nil {
+			t.Fatalf("failed to write mock response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	// Create RBAC client pointing to mock server
+	client := NewRbacClient(server.URL, nil, 10*time.Second, RbacClientConfig{}, nil).(*rbacClientImpl)
+
+	// Create context with request_id via middleware
+	ctx := contextWithRequestID(t)
+
+	// Add identity to context
+	ctx = identity.WithIdentity(ctx, identity.XRHID{
+		Identity: identity.Identity{
+			Type:  "User",
+			OrgID: "org-concurrent",
+			User: &identity.User{
+				UserID: "user-concurrent",
+			},
+		},
+	})
+
+	// Launch 5 concurrent requests
+	results := make(chan string, 5)
+	errors := make(chan error, 5)
+
+	for i := 0; i < 5; i++ {
+		go func() {
+			workspaceID, err := client.GetDefaultWorkspaceIDWithCache(ctx, "org-concurrent")
+			results <- workspaceID
+			errors <- err
+		}()
+	}
+
+	// Collect all results
+	var allWorkspaceIDs []string
+	var allErrors []error
+	for i := 0; i < 5; i++ {
+		allWorkspaceIDs = append(allWorkspaceIDs, <-results)
+		allErrors = append(allErrors, <-errors)
+	}
+
+	// Verify all succeeded
+	for i, err := range allErrors {
+		assert.NoError(t, err, "Request %d should succeed", i)
+	}
+
+	// Verify all got the same result
+	for i, workspaceID := range allWorkspaceIDs {
+		assert.Equal(t, "workspace-123", workspaceID, "Request %d should get correct workspace ID", i)
+	}
+
+	// Most importantly: singleflight should deduplicate, so only 1 backend call
+	assert.Equal(t, 1, callCount, "Singleflight should deduplicate concurrent requests to 1 backend call")
+}
+
+// TestGetDefaultWorkspaceIDWithCache_TypeAssertionFailure verifies that corrupted workspace cache entries
+// (wrong type) are detected, deleted, and the code falls through to fetch from API.
+func TestGetDefaultWorkspaceIDWithCache_TypeAssertionFailure(t *testing.T) {
+	// Create RBAC client
+	client := NewRbacClient("http://localhost:8080", nil, 10*time.Second, RbacClientConfig{}, nil).(*rbacClientImpl)
+
+	// Create context with request_id via middleware
+	ctx := contextWithRequestID(t)
+
+	// Add identity to context
+	ctx = identity.WithIdentity(ctx, identity.XRHID{
+		Identity: identity.Identity{
+			Type:  "User",
+			OrgID: "org-badtype",
+			User: &identity.User{
+				UserID: "user-badtype",
+			},
+		},
+	})
+
+	// Manually corrupt the cache with wrong type ([]string instead of string)
+	reqID := request_id.GetReqID(ctx)
+	cacheKey := hashCacheKey("workspace", reqID, "org-badtype", "user-badtype")
+	client.workspaceCache.Set(cacheKey, []string{"wrong", "type"}, cache.DefaultExpiration)
+
+	// Verify corrupted entry exists
+	corrupted, found := client.workspaceCache.Get(cacheKey)
+	assert.True(t, found, "Corrupted cache entry should exist")
+	corruptedValue, ok := corrupted.([]string)
+	assert.True(t, ok)
+	assert.Equal(t, []string{"wrong", "type"}, corruptedValue, "Should have corrupted value")
+
+	// Call should detect type mismatch in cache, delete it, then try to fetch from API
+	// API call will fail (no mock server) but important thing is it didn't panic
+	_, err := client.GetDefaultWorkspaceIDWithCache(ctx, "org-badtype")
+
+	// Expect error from API call (no mock server), not panic from type assertion
+	assert.Error(t, err, "Should get error from API call, not panic from type assertion")
+
+	// Cache remains empty because API call failed (can't repopulate with fresh data)
+	_, found = client.workspaceCache.Get(cacheKey)
+	assert.False(t, found, "Corrupted cache entry should be deleted and not repopulated after failed API call")
+}
+
+// TestCheckApplicationPermissionsWithCache_SingleflightTypeAssertionSafety verifies that if singleflight.Do
+// returns an unexpected type, we get a descriptive error instead of a panic.
+func TestCheckApplicationPermissionsWithCache_SingleflightTypeAssertionSafety(t *testing.T) {
+	// Create context with request_id via middleware
+	ctx := contextWithRequestID(t)
+
+	// Add identity to context
+	ctx = identity.WithIdentity(ctx, identity.XRHID{
+		Identity: identity.Identity{
+			Type:  "User",
+			OrgID: "org-sftype",
+			User: &identity.User{
+				UserID: "user-sftype",
+			},
+		},
+	})
+
+	// Create a mock that returns the wrong type through the interface{}
+	// In practice this would be a serious bug, but we handle it gracefully
+	mockPermissionCheck := func(ctx context.Context, workspaceID string, serviceFilter string, log *zap.SugaredLogger) ([]string, error) {
+		// Simulate a bug where the function signature is wrong or reflection goes wrong
+		// We can't actually make this return wrong type through the interface{}, so we'll
+		// test the recovery path by having it return nil which should be caught
+		return nil, nil
+	}
+
+	// Create cache client with mock
+	kesselCache := NewKesselClientWithCache(nil)
+	kesselCache.permissionCheckFunc = mockPermissionCheck
+
+	log := zap.NewNop().Sugar()
+
+	// Call should handle nil result gracefully
+	apps, err := kesselCache.CheckApplicationPermissionsWithCache(ctx, "workspace-sftype", "", log)
+
+	// Should succeed with empty list (nil is treated as empty []string)
+	assert.NoError(t, err)
+	assert.Empty(t, apps, "nil should be handled as empty list")
 }

--- a/internal/common/kessel/rbac.go
+++ b/internal/common/kessel/rbac.go
@@ -19,6 +19,7 @@ import (
 	"github.com/project-kessel/inventory-client-go/common"
 	"github.com/redhatinsights/platform-go-middlewares/v2/request_id"
 	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
 )
 
 // RbacClientConfig holds configuration for RBAC client
@@ -82,6 +83,7 @@ type rbacClientImpl struct {
 	tokenTimeout    time.Duration // Timeout for individual token requests
 	tokenMaxRetries int           // Max retry attempts for token acquisition
 	workspaceCache  *cache.Cache
+	workspaceFlight singleflight.Group
 }
 
 // rbacWorkspaceResponse represents the RBAC API response for workspace queries


### PR DESCRIPTION
## What?
fix(kessel): deduplicate concurrent cache misses using singleflight

### OVERVIEW
* Add singleflight groups to RBAC and Kessel cache clients to deduplicate concurrent cache-miss API calls.
* Enhance workspace and application permission lookups to reuse in-flight results and reduce redundant requests.
* Log when workspace and application permission requests are deduplicated for improved observability.

Fixes: RHINENG-30075

``` 

 ┌─────────────────────────────────────────────────────────────────┐
  │                    Request Arrives                              │
  │              (org_id, workspace_id, etc.)                       │
  └─────────────────────┬───────────────────────────────────────────┘
                        │
                        ▼
                ┌───────────────┐
                │  Check Cache  │
                └───────┬───────┘
                        │
            ┌───────────┴────────────┐
            │                        │
       ┌────▼─────┐            ┌─────▼──────┐
       │ HIT ✓    │            │ MISS ✗     │
       └────┬─────┘            └─────┬──────┘
            │                        │
            │                        ▼
            │              ┌──────────────────────┐
            │              │ singleflight.Do()    │
            │              │  (with cache key)    │
            │              └──────┬───────────────┘
            │                     │
            │         ┌───────────┴────────────┐
            │         │                        │
            │   ┌─────▼──────┐          ┌──────▼────────┐
            │   │ First call │          │ Concurrent    │
            │   │ (leader)   │          │ calls         │
            │   │            │          │ (waiters)     │
            │   └─────┬──────┘          └──────┬────────┘
            │         │                        │
            │         ▼                        │
            │   ┌─────────────────┐            │
            │   │ Backend API     │            │
            │   │ (RBAC/Kessel)   │            │
            │   └─────┬───────────┘            │
            │         │                        │
            │         ▼                        │
            │   ┌─────────────────┐            │
            │   │ Write to Cache  │            │
            │   │ (inside Do fn)  │            │
            │   └─────┬───────────┘            │
            │         │                        │
            │         └────────┬───────────────┘
            │                  │
            │                  ▼
            │         ┌─────────────────┐
            │         │ All callers get │
            │         │ shared result   │
            │         └────────┬────────┘
            │                  │
            └──────────────────┘
                        │
                        ▼
                ┌───────────────┐
                │ Return Result │
                └───────────────┘


```

## Summary by Sourcery

Deduplicate concurrent RBAC and Kessel cache misses with singleflight to reduce redundant backend requests.

Bug Fixes:
- Deduplicate concurrent workspace and application permission cache misses to prevent redundant RBAC and Kessel API requests.

Enhancements:
- Add observability for deduplicated permission lookups and strengthen handling of cached and in-flight result types.

Tests:
- Add coverage for singleflight deduplication, concurrent lookup behavior, cache type mismatches, and result safety.