### PR TITLE
RHINENG-30159: limit decompressed file size

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -312,6 +312,8 @@ objects:
             value: ${STORAGE_MAX_CONCURRENCY}
           - name: ARTIFACT_MAX_SIZE
             value: ${ARTIFACT_MAX_SIZE}
+          - name: ARTIFACT_MAX_DECOMPRESSED_SIZE
+            value: ${ARTIFACT_MAX_DECOMPRESSED_SIZE}
           - name: BLOCKLIST_ORG_IDS
             value: ${BLOCKLIST_ORG_IDS}
         resources:
@@ -466,6 +468,8 @@ parameters:
   value: "5"
 - name: ARTIFACT_MAX_SIZE
   value: '3145728'
+- name: ARTIFACT_MAX_DECOMPRESSED_SIZE
+  value: '5242880'
 
 - name: RETURN_URL
   value: TBD

--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -65,6 +65,7 @@ func Get() *viper.Viper {
 	options.SetDefault("storage.retries", 3)
 	options.SetDefault("storage.max.concurrency", 5)
 	options.SetDefault("artifact.max.size", 1024*1024)
+	options.SetDefault("artifact.max.decompressed.size", 1024*1024)
 	options.SetDefault("artifact.truncate.stdout.field.after.lines", 500)
 	options.SetDefault("artifact.max.stdout.field.size", 1024)
 	options.SetDefault("artifact.max.kafka.message.size", 1024*1024)

--- a/internal/validator/handler_test.go
+++ b/internal/validator/handler_test.go
@@ -165,7 +165,7 @@ N/Kl0lVn2BIPxggdj5H4qC/Fpj5qlsQYR2/78+KeyhtLY8GqVf/f9r/t1GTtrtO96erY7OnSdMb6
 			len, err := base64.StdEncoding.Decode(decoded, []byte(data))
 			Expect(err).ToNot(HaveOccurred())
 
-			content, err := readFile(bytes.NewReader(decoded[0:len]))
+			content, err := readFile(bytes.NewReader(decoded[0:len]), 10*1024*1024)
 			Expect(err).ToNot(HaveOccurred())
 			events, err := instance.validateContent(test.TestContext(), "playbook", content)
 			Expect(err).ToNot(HaveOccurred())
@@ -196,7 +196,7 @@ fdqPl7IwpOzJmfqrZ1duqTJ62NbTeDDPjOvQ6F70PsJi4KXiLSqngthpIkJLtF3l
 			len, err := base64.StdEncoding.Decode(decoded, []byte(data))
 			Expect(err).ToNot(HaveOccurred())
 
-			content, err := readFile(bytes.NewReader(decoded[0:len]))
+			content, err := readFile(bytes.NewReader(decoded[0:len]), 10*1024*1024)
 			Expect(err).ToNot(HaveOccurred())
 			events, err := instance.validateContent(test.TestContext(), "playbook", content)
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/validator/storage.go
+++ b/internal/validator/storage.go
@@ -3,8 +3,10 @@ package validator
 import (
 	"bufio"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"net/http"
+	"playbook-dispatcher/internal/common/config"
 	commonInstrumentation "playbook-dispatcher/internal/common/instrumentation"
 	"playbook-dispatcher/internal/common/utils"
 	"playbook-dispatcher/internal/validator/instrumentation"
@@ -71,11 +73,17 @@ func (this *storageConnector) fetchPayload(url string) (payload []byte, err erro
 	}
 
 	defer res.Body.Close()
-	payload, err = readFile(res.Body)
+	maxDecompressedSize := config.Get().GetInt64("artifact.max.decompressed.size")
+	payload, err = readFile(res.Body, maxDecompressedSize)
 	return
 }
 
-func readFile(reader io.Reader) (result []byte, err error) {
+func readFile(reader io.Reader, maxDecompressedSize int64) (result []byte, err error) {
+	// Validate limit is positive
+	if maxDecompressedSize <= 0 {
+		return nil, fmt.Errorf("invalid configuration: artifact.max.decompressed.size must be positive, got %d", maxDecompressedSize)
+	}
+
 	reader = bufio.NewReaderSize(reader, 2)
 	compression, err := utils.GetCompressionType(reader)
 	if err != nil {
@@ -97,5 +105,31 @@ func readFile(reader io.Reader) (result []byte, err error) {
 		}
 	}
 
-	return io.ReadAll(reader)
+	// Read the file; if compressed, check against max size
+	// Max artifact size was checked earlier so using maxDecompressedSize for all reads
+	limitedReader := io.LimitReader(reader, maxDecompressedSize)
+	data, err := io.ReadAll(limitedReader)
+	if err != nil {
+		return nil, err
+	}
+
+	// If we read up to exactly the limit, peek ahead one more byte
+	if int64(len(data)) == maxDecompressedSize {
+		// Try to read one more byte to detect oversized files
+		// Assumes storage-backed readers return io.EOF when exhausted, not (0, nil) loops.
+		var extra [1]byte
+		n, err := reader.Read(extra[:])
+
+		// Check for read errors first
+		if err != nil && err != io.EOF {
+			return nil, fmt.Errorf("error reading decompressed archive: %w", err)
+		}
+
+		// Then check if file exceeds limit
+		if n > 0 {
+			return nil, fmt.Errorf("decompressed archive exceeds maximum allowed size (%d bytes)", maxDecompressedSize)
+		}
+	}
+
+	return data, nil
 }

--- a/internal/validator/storage_test.go
+++ b/internal/validator/storage_test.go
@@ -1,11 +1,15 @@
 package validator
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"io"
 	"net/http"
 	"playbook-dispatcher/internal/common/config"
 	"playbook-dispatcher/internal/common/model/message"
 	"playbook-dispatcher/internal/common/utils"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -62,4 +66,169 @@ var _ = Describe("Storage", func() {
 			Expect(end).To(BeNumerically("<", time.Second))
 		})
 	})
+
+	Describe("Read File", func() {
+		It("Reads uncompressed file within limit", func() {
+			content := "test data"
+			reader := strings.NewReader(content)
+
+			data, err := readFile(reader, 100)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(data)).To(Equal(content))
+		})
+
+		It("Rejects uncompressed file exceeding limit", func() {
+			content := strings.Repeat("x", 200)
+			reader := strings.NewReader(content)
+
+			data, err := readFile(reader, 100)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("exceeds maximum allowed size"))
+			Expect(data).To(BeNil())
+		})
+
+		It("Reads gzip compressed file within limit", func() {
+			var buf bytes.Buffer
+			gzWriter := gzip.NewWriter(&buf)
+			_, err := gzWriter.Write([]byte("test data"))
+			Expect(err).ToNot(HaveOccurred())
+			err = gzWriter.Close()
+			Expect(err).ToNot(HaveOccurred())
+
+			data, err := readFile(&buf, 100)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(data)).To(Equal("test data"))
+		})
+
+		It("Rejects gzip compressed file exceeding decompressed limit", func() {
+			// Create large content that compresses well
+			largeContent := strings.Repeat("a", 200)
+			var buf bytes.Buffer
+			gzWriter := gzip.NewWriter(&buf)
+			_, err := gzWriter.Write([]byte(largeContent))
+			Expect(err).ToNot(HaveOccurred())
+			err = gzWriter.Close()
+			Expect(err).ToNot(HaveOccurred())
+
+			data, err := readFile(&buf, 100)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("exceeds maximum allowed size"))
+			Expect(data).To(BeNil())
+		})
+
+		It("Rejects invalid negative limit", func() {
+			reader := strings.NewReader("test")
+
+			data, err := readFile(reader, -1)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must be positive"))
+			Expect(data).To(BeNil())
+		})
+
+		It("Rejects zero limit", func() {
+			reader := strings.NewReader("test")
+
+			data, err := readFile(reader, 0)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must be positive"))
+			Expect(data).To(BeNil())
+		})
+
+		It("Accepts uncompressed file exactly at the limit", func() {
+			content := strings.Repeat("x", 100)
+			reader := strings.NewReader(content)
+
+			data, err := readFile(reader, 100)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(data)).To(Equal(100))
+		})
+
+		It("Accepts gzip compressed file with decompressed content exactly at the limit", func() {
+			// Create exactly 100 bytes of content
+			content := strings.Repeat("x", 100)
+			var buf bytes.Buffer
+			gzWriter := gzip.NewWriter(&buf)
+			_, err := gzWriter.Write([]byte(content))
+			Expect(err).ToNot(HaveOccurred())
+			err = gzWriter.Close()
+			Expect(err).ToNot(HaveOccurred())
+
+			data, err := readFile(&buf, 100)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(data)).To(Equal(100))
+			Expect(string(data)).To(Equal(content))
+		})
+
+		It("Handles read errors during decompression", func() {
+			// Create a corrupted gzip stream: valid header, then error mid-stream
+			var buf bytes.Buffer
+			gzWriter := gzip.NewWriter(&buf)
+			_, err := gzWriter.Write([]byte("some data"))
+			Expect(err).ToNot(HaveOccurred())
+			err = gzWriter.Close()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Take the gzip header but corrupt the compressed data
+			gzipBytes := buf.Bytes()
+			corruptedReader := &corruptedGzipReader{
+				data:  gzipBytes[:10], // Valid gzip header
+				index: 0,
+			}
+
+			data, err := readFile(corruptedReader, 100)
+			Expect(err).To(HaveOccurred())
+			Expect(data).To(BeNil())
+		})
+
+		It("Handles read errors during overflow probe", func() {
+			// Create a reader that returns exactly 100 bytes, then a non-EOF error
+			exactReader := &exactSizeThenErrorReader{
+				data: []byte(strings.Repeat("x", 100)),
+				err:  io.ErrUnexpectedEOF,
+			}
+
+			data, err := readFile(exactReader, 100)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("error reading decompressed archive"))
+			Expect(data).To(BeNil())
+		})
+	})
 })
+
+// Helper for testing corrupted gzip stream
+type corruptedGzipReader struct {
+	data  []byte
+	index int
+}
+
+func (c *corruptedGzipReader) Read(p []byte) (n int, err error) {
+	if c.index >= len(c.data) {
+		// After header, return error to simulate corrupted stream
+		return 0, io.ErrUnexpectedEOF
+	}
+	n = copy(p, c.data[c.index:])
+	c.index += n
+	return n, nil
+}
+
+// Helper for testing error during overflow probe
+type exactSizeThenErrorReader struct {
+	data     []byte
+	index    int
+	err      error
+	returned bool
+}
+
+func (e *exactSizeThenErrorReader) Read(p []byte) (n int, err error) {
+	if e.index >= len(e.data) {
+		// Data exhausted, now return error on overflow probe
+		if !e.returned {
+			e.returned = true
+			return 0, e.err
+		}
+		return 0, io.EOF
+	}
+	n = copy(p, e.data[e.index:])
+	e.index += n
+	return n, nil
+}


### PR DESCRIPTION
* Adds configurable limits for decompressed artifacts
* Deployment configuration
* Validation that rejects files exceeding the maximum allowed decompressed size.

Fixes: RHINENG-30159

## Summary by Sourcery

Limit artifact decompression to a configurable maximum size and reject oversized or invalid inputs.

New Features:
- Add a configurable maximum decompressed artifact size for validation.

Bug Fixes:
- Reject artifacts whose decompressed contents exceed the configured limit, including compressed and uncompressed files.
- Reject invalid non-positive decompressed-size configuration values.

Deployment:
- Expose and configure the decompressed artifact size limit in the deployment configuration.

Tests:
- Add coverage for decompressed-size limits, boundary conditions, invalid configuration, and read errors.